### PR TITLE
Add extension methods for doing reflection

### DIFF
--- a/src/Reflection/ObjectMethodInvokeExtensions.cs
+++ b/src/Reflection/ObjectMethodInvokeExtensions.cs
@@ -63,6 +63,29 @@ namespace RapidCore.Reflection
             return method.Invoke(instance, null);
         }
 
+        /// <summary>
+        /// Invoke property setter recursively
+        /// </summary>
+        /// <param name="instance">The instance</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <parma name="value">The value to set</param>
+        /// <exception cref="System.MissingMethodException">Thrown if the property does not have a setter</exception>
+        /// <exception cref="System.MissingMemberException">Thrown if the property does not exist</exception>
+        public static void InvokeSetterRecursively(this object instance, string propertyName, object value)
+        {
+            var method = instance
+                .GetType()
+                .GetPropertyRecursively(propertyName)
+                .SetMethod;
+
+            if (method == null)
+            {
+                throw new MissingMethodException($"The property {propertyName} does not have a setter");
+            }
+
+            method.Invoke(instance, new object[] { value });
+        }
+
         private static Type[] GetTypeArray(object[] args)
         {
             return args.Select(a => a.GetType()).ToArray();

--- a/src/Reflection/ObjectMethodInvokeExtensions.cs
+++ b/src/Reflection/ObjectMethodInvokeExtensions.cs
@@ -9,7 +9,7 @@ namespace RapidCore.Reflection
     public static class ObjectMethodInvokeExtensions
     {
         /// <summary>
-        /// Invoke a method recursively on the given instance
+        /// Invoke a method recursively
         /// </summary>
         /// <param name="instance">The instance</param>
         /// <param name="methodName">The name of the method</param>
@@ -20,6 +20,23 @@ namespace RapidCore.Reflection
             return instance
                 .GetType()
                 .GetMethodRecursively(methodName, GetTypeArray(args))
+                .Invoke(instance, args);
+        }
+
+        /// <summary>
+        /// Invoke a generic method recursively
+        /// </summary>
+        /// <param name="instance">The instance</param>
+        /// <param name="methodName">The name of the method</param>
+        /// <param name="genericTypes">The generic type arguments</param>
+        /// <param name="args">The arguments for the method</param>
+        /// <returns></returns>
+        public static object InvokeGenericMethodRecursively(this object instance, string methodName, Type[] genericTypes, params object[] args)
+        {
+            return instance
+                .GetType()
+                .GetMethodRecursively(methodName, GetTypeArray(args))
+                .MakeGenericMethod(genericTypes)
                 .Invoke(instance, args);
         }
 

--- a/src/Reflection/ObjectMethodInvokeExtensions.cs
+++ b/src/Reflection/ObjectMethodInvokeExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+
+namespace RapidCore.Reflection
+{
+    /// <summary>
+    /// Extension methods for invoking methods through <see cref="System.Object" />
+    /// </summary>
+    public static class ObjectMethodInvokeExtensions
+    {
+        /// <summary>
+        /// Invoke a method recursively on the given instance
+        /// </summary>
+        /// <param name="instance">The instance</param>
+        /// <param name="methodName">The name of the method</param>
+        /// <param name="args">The arguments for the method</param>
+        /// <returns>Whatever the called method returns</returns>
+        public static object InvokeMethodRecursively(this object instance, string methodName, params object[] args)
+        {
+            return instance
+                .GetType()
+                .GetMethodRecursively(methodName, GetTypeArray(args))
+                .Invoke(instance, args);
+        }
+
+        private static Type[] GetTypeArray(object[] args)
+        {
+            return args.Select(a => a.GetType()).ToArray();
+        }
+    }
+}

--- a/src/Reflection/ObjectMethodInvokeExtensions.cs
+++ b/src/Reflection/ObjectMethodInvokeExtensions.cs
@@ -40,6 +40,29 @@ namespace RapidCore.Reflection
                 .Invoke(instance, args);
         }
 
+        /// <summary>
+        /// Invoke property getter recursively
+        /// </summary>
+        /// <param name="instance">The instance</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <returns>The value of the property</returns>
+        /// <exception cref="System.MissingMethodException">Thrown if the property does not have a getter</exception>
+        /// <exception cref="System.MissingMemberException">Thrown if the property does not exist</exception>
+        public static object InvokeGetterRecursively(this object instance, string propertyName)
+        {
+            var method = instance
+                .GetType()
+                .GetPropertyRecursively(propertyName)
+                .GetMethod;
+
+            if (method == null)
+            {
+                throw new MissingMethodException($"The property {propertyName} does not have a getter");
+            }
+
+            return method.Invoke(instance, null);
+        }
+
         private static Type[] GetTypeArray(object[] args)
         {
             return args.Select(a => a.GetType()).ToArray();

--- a/src/Reflection/PropertyInfoAttributesExtensions.cs
+++ b/src/Reflection/PropertyInfoAttributesExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace RapidCore.Reflection
+{
+    /// <summary>
+    /// Extension methods for working with attributes on PropertyInfo
+    /// </summary>
+    public static class PropertyInfoAttributesExtensions
+    {
+        /// <summary>
+        /// Does the property have any instances of the given attribute?
+        /// </summary>
+        /// <param name="prop">The property</param>
+        /// <param name="attribute">The attribute to check for</param>
+        /// <returns><c>True</c> if the property has the attribute, <c>false</c> otherwise</returns>
+        public static bool HasAttribute(this PropertyInfo prop, Type attribute)
+        {
+            return prop.GetSpecificAttribute(attribute).Count > 0;
+        }
+
+        /// <summary>
+        /// Get instances of the given instance
+        /// </summary>
+        /// <param name="prop">The property</param>
+        /// <param name="attribute">The attribute to look for</param>
+        /// <returns>A list of attribute instances</returns>
+        public static List<Attribute> GetSpecificAttribute(this PropertyInfo prop, Type attribute)
+        {
+            return (
+                from a in prop.GetCustomAttributes()
+                where a.GetType() == attribute
+                select a
+            ).ToList();
+        }
+    }
+}

--- a/src/Reflection/TypeGetMethodRecursivelyExtensions.cs
+++ b/src/Reflection/TypeGetMethodRecursivelyExtensions.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace RapidCore.Reflection
+{
+    /// <summary>
+    /// Extension methods for getting a method from a <see cref="System.Type" />
+    /// </summary>
+    public static class TypeGetMethodRecursivelyExtensions
+    {
+        /// <summary>
+        /// Get a method recursively
+        /// </summary>
+        /// <param name="type">The type to work on</param>
+        /// <param name="methodName">The name of the method to get</param>
+        /// <param name="argTypes">The type of the arguments you would use</param>
+        /// <returns>A <see cref="System.Reflection.MethodInfo" /></returns>
+        /// <exception cref="System.MissingMethodException">Thrown if the method could not be found</exception>
+        public static MethodInfo GetMethodRecursively(this Type type, string methodName, params Type[] argTypes)
+        {
+            var typeInfo = type.GetTypeInfo();
+            var method = typeInfo.GetMethod(methodName, argTypes);
+
+            if (method == null && typeInfo.BaseType != null)
+            {
+                method = typeInfo.BaseType.GetMethodRecursively(methodName, argTypes);
+            }
+
+            if (method == null)
+            {
+                throw new MissingMethodException($"Could not find method {GenerateMethodParamsSignature(methodName, argTypes)}");
+            }
+
+            return method;
+        }
+
+        private static string GenerateMethodParamsSignature(string methodName, Type[] argTypes)
+        {
+            var typeSignature = string.Join(", ", argTypes.Select(t => t.Name));
+            return $"{methodName}({typeSignature})";
+        }
+    }
+}

--- a/src/Reflection/TypeGetPropertyRecursivelyExtensions.cs
+++ b/src/Reflection/TypeGetPropertyRecursivelyExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+
+namespace RapidCore.Reflection
+{
+    /// <summary>
+    /// Extension methods for getting properties recursively from <see cref="System.Type" />
+    /// </summary>
+    public static class TypeGetPropertyRecursivelyExtensions
+    {
+        /// <summary>
+        /// Get a property recursively
+        /// </summary>
+        /// <param name="type">The type</param>
+        /// <param name="propertyName">The name of the property</param>
+        /// <returns>The <see cref="System.Reflection.PropertyInfo" /></returns>
+        /// <exception cref="System.MissingMemberException">Thrown if the property does not exist</exception>
+        public static PropertyInfo GetPropertyRecursively(this Type type, string propertyName)
+        {
+            var typeInfo = type.GetTypeInfo();
+
+            var property = typeInfo.GetDeclaredProperty(propertyName);
+
+            if (property == null && typeInfo.BaseType != null)
+            {
+                return typeInfo.BaseType.GetPropertyRecursively(propertyName);
+            }
+
+            if (property == null)
+            {
+                throw new MissingMemberException($"Could not find a property called {propertyName}");
+            }
+
+            return property;
+        }
+    }
+}

--- a/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
+++ b/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
@@ -101,14 +101,10 @@ namespace RapidCore.UnitTests.Reflection
         [Fact]
         public void InvokeGetterRecursively_Throws_ifThereIsNoGetter()
         {
-            try
-            {
-                guineaPig.InvokeGetterRecursively("SetterOnly");
-            }
-            catch (MissingMethodException ex)
-            {
-                Assert.Equal("The property SetterOnly does not have a getter", ex.Message);
-            }
+
+            var ex = Assert.Throws<MissingMethodException>(() => guineaPig.InvokeGetterRecursively("SetterOnly"));
+
+            Assert.Equal("The property SetterOnly does not have a getter", ex.Message);
         }
 
         [Fact]
@@ -136,14 +132,10 @@ namespace RapidCore.UnitTests.Reflection
         [Fact]
         public void InvokeSetterRecursively_Throws_ifThereIsNoSetter()
         {
-            try
-            {
-                guineaPig.InvokeSetterRecursively("Getter", "!");
-            }
-            catch (MissingMethodException ex)
-            {
-                Assert.Equal("The property Getter does not have a setter", ex.Message);
-            }
+
+            var ex = Assert.Throws<MissingMethodException>(() => guineaPig.InvokeSetterRecursively("Getter", "!"));
+
+            Assert.Equal("The property Getter does not have a setter", ex.Message);
         }
 
         [Fact]

--- a/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
+++ b/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Reflection;
+using RapidCore.Reflection;
+using Xunit;
+
+namespace RapidCore.UnitTests.Reflection
+{
+    public class ObjectMethodInvokeExtensionsTests
+    {
+        private readonly GuineaPig guineaPig;
+
+        public ObjectMethodInvokeExtensionsTests()
+        {
+            guineaPig = new GuineaPig();
+        }
+
+        [Fact]
+        public void InvokeMethodRecursively_CanInvoke_void_withOneParam()
+        {
+            var actual = guineaPig.InvokeMethodRecursively("OneParam", "hi");
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void InvokeMethodRecursively_CanInvoke_void_withNoParams()
+        {
+            var actual = guineaPig.InvokeMethodRecursively("ZeroParams");
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void InvokeMethodRecursively_CanInvoke_withOneParam_andReturnValue()
+        {
+            var actual = guineaPig.InvokeMethodRecursively("OneParamWithReturn", "hi");
+
+            Assert.Equal("hi", actual);
+        }
+
+        [Fact]
+        public void InvokeMethodRecursively_CanInvoke_withNoParams_andReturnValue()
+        {
+            var actual = guineaPig.InvokeMethodRecursively("ZeroParamsWithReturn");
+
+            Assert.Equal(666, actual);
+        }
+
+        [Fact]
+        public void InvokeMethodRecursively_CanInvoke_inNextLayer()
+        {
+            var actual = guineaPig.InvokeMethodRecursively("GetType");
+
+            Assert.IsAssignableFrom(typeof(Type), actual.GetType());
+        }
+
+        #region GuineaPig
+        private class GuineaPig
+        {
+            public void OneParam(string a) { }
+
+            public string OneParamWithReturn(string a) { return a; }
+
+            public void ZeroParams() { }
+
+            public int ZeroParamsWithReturn() { return 666; }
+        }
+        #endregion
+    }
+}

--- a/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
+++ b/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
@@ -70,6 +70,53 @@ namespace RapidCore.UnitTests.Reflection
             Assert.Equal("hello from the base of Attribute", actual);
         }
 
+        [Fact]
+        public void InvokeGetterRecursively_GetterAndSetter_inFirstLayer()
+        {
+            guineaPig.GetterAndSetter = "yo";
+
+            var actual = guineaPig.InvokeGetterRecursively("GetterAndSetter");
+
+            Assert.Equal("yo", actual);
+        }
+
+        [Fact]
+        public void InvokeGetterRecursively_GetterAndSetter_inNextLayer()
+        {
+            guineaPig.AllAboutThatBase = "aahhhhh yeah";
+
+            var actual = guineaPig.InvokeGetterRecursively("AllAboutThatBase");
+
+            Assert.Equal("aahhhhh yeah", actual);
+        }
+
+        [Fact]
+        public void InvokeGetterRecursively_Getter_inFirstLayer()
+        {
+            var actual = guineaPig.InvokeGetterRecursively("Getter");
+
+            Assert.Equal("getter only", actual);
+        }
+
+        [Fact]
+        public void InvokeGetterRecursively_Throws_ifThereIsNoGetter()
+        {
+            try
+            {
+                guineaPig.InvokeGetterRecursively("SetterOnly");
+            }
+            catch (MissingMethodException ex)
+            {
+                Assert.Equal("The property SetterOnly does not have a getter", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void InvokeGetterRecursively_Throws_ifThePropertyDoesNotExist()
+        {
+            Assert.ThrowsAny<MissingMemberException>(() => guineaPig.InvokeGetterRecursively("DoesNotExist"));
+        }
+
         #region GuineaPig
         private class GuineaPig : GuineaPigBase
         {
@@ -82,11 +129,27 @@ namespace RapidCore.UnitTests.Reflection
             public int ZeroParamsWithReturn() { return 666; }
 
             public string Generic<T>(string b) { return $"{b} {typeof(T).Name}"; }
+
+            public string GetterAndSetter { get; set; }
+
+            public string Getter => "getter only";
+
+            private string setterOnly;
+
+            public string SetterOnly
+            {
+                set
+                {
+                    setterOnly = value;
+                }
+            }
         }
 
         private abstract class GuineaPigBase
         {
             public string Generic<T>(string b, string c) { return $"{b} {c} {typeof(T).Name}"; }
+
+            public string AllAboutThatBase { get; set; }
         }
         #endregion
     }

--- a/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
+++ b/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
@@ -117,6 +117,41 @@ namespace RapidCore.UnitTests.Reflection
             Assert.ThrowsAny<MissingMemberException>(() => guineaPig.InvokeGetterRecursively("DoesNotExist"));
         }
 
+        [Fact]
+        public void InvokeSetterRecursively_GetterAndSetter_inFirstLayer()
+        {
+            guineaPig.InvokeSetterRecursively("GetterAndSetter", "hephey");
+
+            Assert.Equal("hephey", guineaPig.GetterAndSetter);
+        }
+
+        [Fact]
+        public void InvokeSetterRecursively_GetterAndSetter_inNextLayer()
+        {
+            guineaPig.InvokeSetterRecursively("AllAboutThatBase", "hephey");
+
+            Assert.Equal("hephey", guineaPig.AllAboutThatBase);
+        }
+
+        [Fact]
+        public void InvokeSetterRecursively_Throws_ifThereIsNoSetter()
+        {
+            try
+            {
+                guineaPig.InvokeSetterRecursively("Getter", "!");
+            }
+            catch (MissingMethodException ex)
+            {
+                Assert.Equal("The property Getter does not have a setter", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void InvokeSetterRecursively_Throws_ifThePropertyDoesNotExist()
+        {
+            Assert.ThrowsAny<MissingMemberException>(() => guineaPig.InvokeSetterRecursively("DoesNotExist", "!"));
+        }
+
         #region GuineaPig
         private class GuineaPig : GuineaPigBase
         {

--- a/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
+++ b/test/unit/Reflection/ObjectMethodInvokeExtensionsTests.cs
@@ -54,8 +54,24 @@ namespace RapidCore.UnitTests.Reflection
             Assert.IsAssignableFrom(typeof(Type), actual.GetType());
         }
 
+        [Fact]
+        public void InvokeGenericMethodRecursively_firstLayer()
+        {
+            var actual = guineaPig.InvokeGenericMethodRecursively("Generic", new Type[] { typeof(Attribute) }, "hello from generic");
+
+            Assert.Equal("hello from generic Attribute", actual);
+        }
+
+        [Fact]
+        public void InvokeGenericMethodRecursively_inNextLayer()
+        {
+            var actual = guineaPig.InvokeGenericMethodRecursively("Generic", new Type[] { typeof(Attribute) }, "hello from", "the base of");
+
+            Assert.Equal("hello from the base of Attribute", actual);
+        }
+
         #region GuineaPig
-        private class GuineaPig
+        private class GuineaPig : GuineaPigBase
         {
             public void OneParam(string a) { }
 
@@ -64,6 +80,13 @@ namespace RapidCore.UnitTests.Reflection
             public void ZeroParams() { }
 
             public int ZeroParamsWithReturn() { return 666; }
+
+            public string Generic<T>(string b) { return $"{b} {typeof(T).Name}"; }
+        }
+
+        private abstract class GuineaPigBase
+        {
+            public string Generic<T>(string b, string c) { return $"{b} {c} {typeof(T).Name}"; }
         }
         #endregion
     }

--- a/test/unit/Reflection/PropertyInfoAttributesExtensionsTests.cs
+++ b/test/unit/Reflection/PropertyInfoAttributesExtensionsTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using RapidCore.Reflection;
+using Xunit;
+
+namespace RapidCore.UnitTests.Reflection
+{
+    public class PropertyInfoAttributesExtensionsTests
+    {
+        [Theory]
+        [InlineDataAttribute("HasObsoleteAttrib", typeof(ObsoleteAttribute), true)] // returns true when it has the attribute
+        [InlineDataAttribute("HasObsoleteAttrib", typeof(DisplayNameAttribute), false)] // returns false when it does not have the attribute, although it has another attribute
+        [InlineDataAttribute("HasNoAttrib", typeof(DisplayNameAttribute), false)] // returns false when it does not have the attribute
+        public void HasAttribute(string propertyName, Type attributeType, bool expected)
+        {
+            Assert.Equal(expected, GetProperty(propertyName).HasAttribute(attributeType));
+        }
+
+        [Fact]
+        public void GetSpecificAttribute_returnAttributeInstance_whenItExists()
+        {
+            var actual = GetProperty("HasObsoleteAttrib").GetSpecificAttribute(typeof(ObsoleteAttribute));
+
+            Assert.Equal(1, actual.Count);
+            Assert.IsType(typeof(ObsoleteAttribute), actual[0]);
+        }
+
+        [Fact]
+        public void GetSpecificAttribute_returnsEmptyList_whenItDoesNotHaveTheAttribute()
+        {
+            var actual = GetProperty("HasNoAttrib").GetSpecificAttribute(typeof(ObsoleteAttribute));
+
+            Assert.Empty(actual);
+        }
+
+        private PropertyInfo GetProperty(string propertyName)
+        {
+            return typeof(GuineaPig).GetTypeInfo().GetProperty(propertyName);
+        }
+
+        #region GuineaPig
+        private class GuineaPig
+        {
+            [Obsolete]
+            public string HasObsoleteAttrib { get; set; }
+
+            [DisplayName]
+            public string HasDisplayNameAttrib { get; set; }
+
+            public string HasNoAttrib { get; set; }
+        }
+        #endregion
+    }
+}

--- a/test/unit/Reflection/TypeGetMethodRecursivelyExtensionsTests.cs
+++ b/test/unit/Reflection/TypeGetMethodRecursivelyExtensionsTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Reflection;
+using RapidCore.Reflection;
+using Xunit;
+
+namespace RapidCore.UnitTests.Reflection
+{
+    public class TypeGetMethodRecursivelyExtensionsTests
+    {
+        [Fact]
+        public void GetMethodRecursively_FindsMethodsWithParams_InFirstLayer()
+        {
+            var actual = typeof(GuineaPig).GetMethodRecursively("OneParam", typeof(string));
+            
+            Assert.NotNull(actual);
+            Assert.Equal("OneParam", actual.Name);
+        }
+
+        [Fact]
+        public void GetMethodRecursively_FindsMethodsWithoutParams_InFirstLayer()
+        {
+            var actual = typeof(GuineaPig).GetMethodRecursively("ZeroParams");
+            
+            Assert.NotNull(actual);
+            Assert.Equal("ZeroParams", actual.Name);
+        }
+
+        [Fact]
+        public void GetMethodRecursively_FindsOverloadedMethodsWithoutParams()
+        {
+            var actual = typeof(GuineaPig).GetMethodRecursively("HasOverload");
+            
+            Assert.NotNull(actual);
+            Assert.Equal("HasOverload", actual.Name);
+            Assert.Empty(actual.GetParameters());
+        }
+
+        [Fact]
+        public void GetMethodRecursively_FindsOverloadedMethodsWithParams()
+        {
+            var actual = typeof(GuineaPig).GetMethodRecursively("HasOverload", typeof(Attribute));
+            
+            Assert.NotNull(actual);
+            Assert.Equal("HasOverload", actual.Name);
+            Assert.Equal(1, actual.GetParameters().Length);
+        }
+
+        [Fact]
+        public void GetMethodRecursively_FindsMethodsWithoutParams_InNextLayer()
+        {
+            var actual = typeof(GuineaPig).GetMethodRecursively("GetType");
+            
+            Assert.NotNull(actual);
+            Assert.Equal("GetType", actual.Name);
+            Assert.Equal(typeof(Object), actual.DeclaringType);
+        }
+
+        [Fact]
+        public void GetMethodRecursively_Throws_ifMethodDoesNotExist_withoutParams()
+        {
+            try
+            {
+                typeof(GuineaPig).GetMethodRecursively("DoesNotExist");
+            }
+            catch (MissingMethodException ex)
+            {
+                Assert.Equal("Could not find method DoesNotExist()", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void GetMethodRecursively_Throws_ifMethodDoesNotExist_singleParam()
+        {
+            try
+            {
+                typeof(GuineaPig).GetMethodRecursively("DoesNotExist", typeof(long));
+            }
+            catch (MissingMethodException ex)
+            {
+                Assert.Equal("Could not find method DoesNotExist(Int64)", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void GetMethodRecursively_Throws_ifMethodDoesNotExist_multipleParams()
+        {
+            try
+            {
+                typeof(GuineaPig).GetMethodRecursively("DoesNotExist", typeof(long), typeof(int), typeof(Attribute));
+            }
+            catch (MissingMethodException ex)
+            {
+                Assert.Equal("Could not find method DoesNotExist(Int64, Int32, Attribute)", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void GetMethodRecursively_Throws_ifMethodDoesNotExist_withThoseParameters()
+        {
+            try
+            {
+                typeof(GuineaPig).GetMethodRecursively("HasOverload", typeof(long), typeof(int), typeof(Attribute));
+            }
+            catch (MissingMethodException ex)
+            {
+                Assert.Equal("Could not find method HasOverload(Int64, Int32, Attribute)", ex.Message);
+            }
+        }
+
+        #region GuineaPig
+        private class GuineaPig
+        {
+            public void OneParam(string a) { }
+
+            public void ZeroParams() { }
+
+            public void HasOverload() { }
+
+            public void HasOverload(Attribute attrib) { }
+        }
+        #endregion
+    }
+}

--- a/test/unit/Reflection/TypeGetMethodRecursivelyExtensionsTests.cs
+++ b/test/unit/Reflection/TypeGetMethodRecursivelyExtensionsTests.cs
@@ -58,53 +58,35 @@ namespace RapidCore.UnitTests.Reflection
         [Fact]
         public void GetMethodRecursively_Throws_ifMethodDoesNotExist_withoutParams()
         {
-            try
-            {
-                typeof(GuineaPig).GetMethodRecursively("DoesNotExist");
-            }
-            catch (MissingMethodException ex)
-            {
-                Assert.Equal("Could not find method DoesNotExist()", ex.Message);
-            }
+
+            var ex = Assert.Throws<MissingMethodException>(() => typeof(GuineaPig).GetMethodRecursively("DoesNotExist"));
+
+            Assert.Equal("Could not find method DoesNotExist()", ex.Message);
         }
 
         [Fact]
         public void GetMethodRecursively_Throws_ifMethodDoesNotExist_singleParam()
         {
-            try
-            {
-                typeof(GuineaPig).GetMethodRecursively("DoesNotExist", typeof(long));
-            }
-            catch (MissingMethodException ex)
-            {
-                Assert.Equal("Could not find method DoesNotExist(Int64)", ex.Message);
-            }
+            var ex = Assert.Throws<MissingMethodException>(() => typeof(GuineaPig).GetMethodRecursively("DoesNotExist", typeof(long)));
+
+            Assert.Equal("Could not find method DoesNotExist(Int64)", ex.Message);
         }
 
         [Fact]
         public void GetMethodRecursively_Throws_ifMethodDoesNotExist_multipleParams()
         {
-            try
-            {
-                typeof(GuineaPig).GetMethodRecursively("DoesNotExist", typeof(long), typeof(int), typeof(Attribute));
-            }
-            catch (MissingMethodException ex)
-            {
-                Assert.Equal("Could not find method DoesNotExist(Int64, Int32, Attribute)", ex.Message);
-            }
+
+            var ex = Assert.Throws<MissingMethodException>(() => typeof(GuineaPig).GetMethodRecursively("DoesNotExist", typeof(long), typeof(int), typeof(Attribute)));
+
+            Assert.Equal("Could not find method DoesNotExist(Int64, Int32, Attribute)", ex.Message);
         }
 
         [Fact]
         public void GetMethodRecursively_Throws_ifMethodDoesNotExist_withThoseParameters()
         {
-            try
-            {
-                typeof(GuineaPig).GetMethodRecursively("HasOverload", typeof(long), typeof(int), typeof(Attribute));
-            }
-            catch (MissingMethodException ex)
-            {
-                Assert.Equal("Could not find method HasOverload(Int64, Int32, Attribute)", ex.Message);
-            }
+            var ex = Assert.Throws<MissingMethodException>(() => typeof(GuineaPig).GetMethodRecursively("HasOverload", typeof(long), typeof(int), typeof(Attribute)));
+
+            Assert.Equal("Could not find method HasOverload(Int64, Int32, Attribute)", ex.Message);
         }
 
         #region GuineaPig

--- a/test/unit/Reflection/TypeGetPropertyRecursivelyExtensionsTests.cs
+++ b/test/unit/Reflection/TypeGetPropertyRecursivelyExtensionsTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Reflection;
+using RapidCore.Reflection;
+using Xunit;
+
+namespace RapidCore.UnitTests.Reflection
+{
+    public class TypeGetPropertyRecursivelyExtensionsTests
+    {
+        [Fact]
+        public void GetPropertyRecursively_canFindIt_inFirstLayer()
+        {
+            var actual = typeof(GuineaPig).GetPropertyRecursively("FirstLayer");
+
+            Assert.Equal("FirstLayer", actual.Name);
+        }
+
+        [Fact]
+        public void GetPropertyRecursively_canFindIt_inNextLayer()
+        {
+            var actual = typeof(GuineaPig).GetPropertyRecursively("SecondLayer");
+
+            Assert.Equal("SecondLayer", actual.Name);
+        }
+
+        [Fact]
+        public void GetPropertyRecursively_throwsIfNoSuchProperty()
+        {
+            try
+            {
+                typeof(GuineaPig).GetPropertyRecursively("DoesNotExist");
+            }
+            catch (MissingMemberException ex)
+            {
+                Assert.Equal("Could not find a property called DoesNotExist", ex.Message);
+            }
+        }
+
+        #region GuineaPig
+        private class GuineaPig : GuineaPigBase
+        {
+            public string FirstLayer { get; set; }
+        }
+
+        private abstract class GuineaPigBase
+        {
+            public int SecondLayer { get; set; }
+        }
+        #endregion
+    }
+}

--- a/test/unit/Reflection/TypeGetPropertyRecursivelyExtensionsTests.cs
+++ b/test/unit/Reflection/TypeGetPropertyRecursivelyExtensionsTests.cs
@@ -26,14 +26,9 @@ namespace RapidCore.UnitTests.Reflection
         [Fact]
         public void GetPropertyRecursively_throwsIfNoSuchProperty()
         {
-            try
-            {
-                typeof(GuineaPig).GetPropertyRecursively("DoesNotExist");
-            }
-            catch (MissingMemberException ex)
-            {
-                Assert.Equal("Could not find a property called DoesNotExist", ex.Message);
-            }
+            var ex = Assert.Throws<MissingMemberException>(() => typeof(GuineaPig).GetPropertyRecursively("DoesNotExist"));
+
+            Assert.Equal("Could not find a property called DoesNotExist", ex.Message);
         }
 
         #region GuineaPig


### PR DESCRIPTION
They all live in the `RapidCore.Reflection` namespace. Should they be moved to `RapidCore.Reflection.Extensions`?

There are extensions for getting properties and methods recursively (i.e. go through the inheritance tree until method/property is found). These were implemented to support extensions that call methods/getters/setters on Object.

Also added extension methods for `PropertyInfo` that makes it easier to work with attributes.