### PR TITLE
Add helper class for working with environment variables

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -31,9 +31,6 @@ $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
 exec { & dotnet build }
 
-# define an environment variable that we can use in our unit tests
-$env:TestVariable = "This is a test environment variable."
-
 exec { & dotnet test .\test\unit\unittests.csproj -c Release }
 
 exec { & dotnet pack .\src\rapidcore.csproj -c Release -o ..\artifacts --include-source }

--- a/Build.ps1
+++ b/Build.ps1
@@ -31,6 +31,9 @@ $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
 exec { & dotnet build }
 
+# define an environment variable that we can use in our unit tests
+$env:TestVariable = "This is a test environment variable."
+
 exec { & dotnet test .\test\unit\unittests.csproj -c Release }
 
 exec { & dotnet pack .\src\rapidcore.csproj -c Release -o ..\artifacts --include-source }

--- a/src/Environment/EnvironmentVariables.cs
+++ b/src/Environment/EnvironmentVariables.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace RapidCore.Environment
+{
+    /// <summary>
+    /// Convenient and mockable methods
+    /// for working with environment variables.
+    /// </summary>
+    public class EnvironmentVariables
+    {
+        /// <summary>
+        /// Get the value of an environment variable. If the value
+        /// does not exist or is empty, the <paramref name="defaultValue"/> will
+        /// be returned instead.
+        /// </summary>
+        /// <param name="key">The key/name of the variable</param>
+        /// <param name="defaultValue">The value to use if the environment does not have one</param>
+        /// <returns>The environment's value for <paramref name="key"/> or <paramref name="defaultValue"/></returns>
+        public virtual T Get<T>(string key, T defaultValue)
+        {
+            var value = System.Environment.GetEnvironmentVariable(key);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+
+        /// <summary>
+        /// Get _all_ environment variables ordered by name
+        /// </summary>
+        /// <returns>A sorted dictionary with _all_ defined environment variables</returns>
+        public virtual SortedDictionary<string, string> AllSorted()
+        {
+            var idictionary = System.Environment.GetEnvironmentVariables();
+            var sorted = new SortedDictionary<string, string>();
+
+            foreach (DictionaryEntry de in idictionary)
+            {
+                sorted.Add(de.Key.ToString(), de.Value.ToString());
+            }
+
+            return sorted;
+        }
+    }
+}

--- a/test/unit/Environment/EnvironmentVariablesTests.cs
+++ b/test/unit/Environment/EnvironmentVariablesTests.cs
@@ -1,0 +1,42 @@
+using RapidCore.Environment;
+using Xunit;
+
+namespace RapidCore.UnitTests.Environment
+{
+    public class EnvironmentVariablesTests
+    {
+        private readonly EnvironmentVariables envVariables;
+
+        public EnvironmentVariablesTests()
+        {
+            envVariables = new EnvironmentVariables();
+        }
+
+        [Fact]
+        public void Get_ReturnsDefault_IfEnvHasNoValue()
+        {
+            var actual = envVariables.Get<string>("some_key_that_definitely_does_not_exist", "the glorious default");
+
+            Assert.Equal("the glorious default", actual);
+        }
+
+        [Fact]
+        public void Get_ReturnsValue_ifExists()
+        {
+            var actual = envVariables.Get<string>("PATH", "default");
+
+            var expected = System.Environment.GetEnvironmentVariable("PATH");
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void AllSorted()
+        {
+            var actual = envVariables.AllSorted();
+
+            Assert.True(actual.Count > 0);
+            Assert.True(actual.ContainsKey("PATH"));
+        }
+    }
+}

--- a/test/unit/Environment/EnvironmentVariablesTests.cs
+++ b/test/unit/Environment/EnvironmentVariablesTests.cs
@@ -23,9 +23,9 @@ namespace RapidCore.UnitTests.Environment
         [Fact]
         public void Get_ReturnsValue_ifExists()
         {
-            var actual = envVariables.Get<string>("PATH", "default");
+            var actual = envVariables.Get<string>("DOTNET_CLI_TELEMETRY_SESSIONID", "default");
 
-            var expected = System.Environment.GetEnvironmentVariable("PATH");
+            var expected = System.Environment.GetEnvironmentVariable("DOTNET_CLI_TELEMETRY_SESSIONID");
 
             Assert.Equal(expected, actual);
         }
@@ -35,13 +35,8 @@ namespace RapidCore.UnitTests.Environment
         {
             var actual = envVariables.AllSorted();
 
-            foreach (var kvp in actual)
-            {
-                System.Console.WriteLine($"{kvp.Key} = {kvp.Value}");
-            }
-
             Assert.True(actual.Count > 0, "There should be at least 1 variable defined");
-            Assert.True(actual.ContainsKey("PATH"), "As a minimum 'PATH' should be defined");
+            Assert.True(actual.ContainsKey("DOTNET_CLI_TELEMETRY_SESSIONID"), "As a minimum 'DOTNET_CLI_TELEMETRY_SESSIONID' should be defined");
         }
     }
 }

--- a/test/unit/Environment/EnvironmentVariablesTests.cs
+++ b/test/unit/Environment/EnvironmentVariablesTests.cs
@@ -35,8 +35,13 @@ namespace RapidCore.UnitTests.Environment
         {
             var actual = envVariables.AllSorted();
 
-            Assert.True(actual.Count > 0);
-            Assert.True(actual.ContainsKey("PATH"));
+            foreach (var kvp in actual)
+            {
+                System.Console.WriteLine($"{kvp.Key} = {kvp.Value}");
+            }
+
+            Assert.True(actual.Count > 0, "There should be at least 1 variable defined");
+            Assert.True(actual.ContainsKey("PATH"), "As a minimum 'PATH' should be defined");
         }
     }
 }


### PR DESCRIPTION
The helper contains 2 methods at present.

1. Get a typed environment variable or a given default value
2. Get a sorted dictionary containing all environment variables (very useful for figuring what is actually defined, rather than having to guess)

I am hoping that I found an environment variable for the tests, that is actually defined on linux, mac and windows.