### PR TITLE
Added abstractions for acquiring distributed application locks

### DIFF
--- a/src/Locking/DistributedAppLockException.cs
+++ b/src/Locking/DistributedAppLockException.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace RapidCore.Locking
+{
+    public class DistributedAppLockException : Exception
+    {
+        public DistributedAppLockException()
+        {
+        }
+
+        public DistributedAppLockException(string message)
+            : base(message)
+        {
+        }
+
+        public DistributedAppLockException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Locking/DistributedAppLockException.cs
+++ b/src/Locking/DistributedAppLockException.cs
@@ -17,5 +17,7 @@ namespace RapidCore.Locking
             : base(message, inner)
         {
         }
+
+        public DistributedAppLockExceptionReason Reason { get; set; }
     }
 }

--- a/src/Locking/DistributedAppLockExceptionReason.cs
+++ b/src/Locking/DistributedAppLockExceptionReason.cs
@@ -1,0 +1,20 @@
+namespace RapidCore.Locking
+{
+    public enum DistributedAppLockExceptionReason
+    {
+        /// <summary>
+        /// Status to use when the lock is acquired by someone else
+        /// </summary>
+        LockAlreadyAcquired,
+
+        /// <summary>
+        /// Timeout acquiring the lock, i.e someone else has acquired it
+        /// </summary>
+        Timeout,
+
+        /// <summary>
+        /// Something horrible happened - check the inner exception for details
+        /// </summary>
+        SeeInnerException
+    }
+}

--- a/src/Locking/IDistributedAppLock.cs
+++ b/src/Locking/IDistributedAppLock.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace RapidCore.Locking
+{
+    /// <summary>
+    /// When implemented in a downstream locker provider, this instance contains a handle to the underlying lock instance
+    /// </summary>
+    public interface IDistributedAppLock : IDisposable
+    {
+        /// <summary>
+        /// The name of the lock acquired
+        /// </summary>
+        string Name { get; set; }
+    }
+}

--- a/src/Locking/IDistributedAppLocker.cs
+++ b/src/Locking/IDistributedAppLocker.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+
+namespace RapidCore.Locking
+{
+    /// <summary>
+    /// Provides an abstraction for acquiring a <see cref="IDistributedAppLock"/> instance that ensures locking across
+    /// all application pools / dotnet core processes running that tries to acquire a lock of the same name
+    /// </summary>
+    public interface IDistributedAppLocker
+    {
+        /// <summary>
+        /// When implemented in a downstream lock class, it will try to acquire the lock in a blocking (sync) manner
+        ///
+        /// If lockWaitTimeout is defined it will wait / retry for the given amount of time before throwing an exception
+        /// and giving up on acquiring the lock
+        /// </summary>
+        /// <exception cref="DistributedAppLockException">Thrown if the lock cannot be acquired</exception>
+        /// <param name="lockName">The name of the lock to acquire</param>
+        /// <param name="lockWaitTimeout">The time to wait / retry acquiring the lock</param>
+        IDistributedAppLock Acquire(string lockName, TimeSpan? lockWaitTimeout = null);
+
+        /// <summary>
+        /// When implemented in a downstream lock class, it will try to acquire the lock in a non-blocking (async) manner
+        ///
+        /// If lockWaitTimeout is defined it will wait / retry for the given amount of time before throwing an exception
+        /// and giving up on acquiring the lock
+        /// </summary>
+        /// <exception cref="DistributedAppLockException">Thrown if the lock cannot be acquired</exception>
+        /// <param name="lockName">The name of the lock to acquire</param>
+        /// <param name="lockWaitTimeout">The time to wait / retry acquiring the lock</param>
+        /// <returns></returns>
+        Task<IDistributedAppLock> AcquireAsync(string lockName, TimeSpan? lockWaitTimeout = null);
+    }
+}

--- a/src/rapidcore.csproj
+++ b/src/rapidcore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <RootNamespace>RapidCore</RootNamespace>
@@ -22,9 +22,11 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta001" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.3.0" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="../stylecop.json" />
     <AdditionalFiles Include="../stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Environment" />
   </ItemGroup>
 </Project>

--- a/test/unit/unittests.csproj
+++ b/test/unit/unittests.csproj
@@ -27,4 +27,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Environment" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit adds pure interfaces for this, as we have no real distributed
app lock to implement here, as it would pull in too many external libraries.

One acquires the lock by creating a new concrete instance of an `IDistributedAppLocker`
which upon acquisition of a lock returns a `IDistributedAppLock` which must be disposed
in order to release the lock handle.

The idea for providers of a Distributed App Lock is that they _must_ guarantee to lock
across all IIS AppPools or dotnet processes running, which are connected to the same
locking coordinator and trying to acquire a lock of the same name. Lock coordinators could
be SQL server, Redis or Apache ZooKeeper.