### PR TITLE
Change interfaces for Distributed app locks

### DIFF
--- a/src/Locking/DistributedAppLockException.cs
+++ b/src/Locking/DistributedAppLockException.cs
@@ -13,9 +13,21 @@ namespace RapidCore.Locking
         {
         }
 
+        public DistributedAppLockException(string message, DistributedAppLockExceptionReason reason)
+            : base(message)
+        {
+            Reason = reason;
+        }
+
         public DistributedAppLockException(string message, Exception inner)
             : base(message, inner)
         {
+        }
+
+        public DistributedAppLockException(string message, Exception inner, DistributedAppLockExceptionReason reason)
+            : base(message, inner)
+        {
+            Reason = reason;
         }
 
         public DistributedAppLockExceptionReason Reason { get; set; }

--- a/src/Locking/IDistributedAppLock.cs
+++ b/src/Locking/IDistributedAppLock.cs
@@ -11,5 +11,20 @@ namespace RapidCore.Locking
         /// The name of the lock acquired
         /// </summary>
         string Name { get; set; }
+
+        /// <summary>
+        /// Determines whether the lock has been taken in the underlying source and is still active
+        /// </summary>
+        bool IsActive { get; set; }
+
+        /// <summary>
+        /// When implemented in a downstream provider it will verify that the current instance of the lock is in an
+        /// active (locked) state and has the name given to the method
+        /// </summary>
+        /// <param name="name"></param>
+        /// <exception cref="InvalidOperationException">
+        /// When the lock is either not active, or has a different name than provided in <paramref name="name"/>
+        /// </exception>
+        void ThrowIfNotActiveWithGivenName(string name);
     }
 }

--- a/src/Locking/IDistributedAppLockProvider.cs
+++ b/src/Locking/IDistributedAppLockProvider.cs
@@ -7,7 +7,7 @@ namespace RapidCore.Locking
     /// Provides an abstraction for acquiring a <see cref="IDistributedAppLock"/> instance that ensures locking across
     /// all application pools / dotnet core processes running that tries to acquire a lock of the same name
     /// </summary>
-    public interface IDistributedAppLocker
+    public interface IDistributedAppLockProvider
     {
         /// <summary>
         /// When implemented in a downstream lock class, it will try to acquire the lock in a blocking (sync) manner


### PR DESCRIPTION
This PR brings breaking changes to the `IDistributedAppLock` and `IDistributedAppLocker`

- `IDistributedAppLock` now contains a new property `IsActive` and a method when implemented that will check whether the lock is currently active and has a correct name
- `IDistributedAppLocker` has been renamed to `IDistributedAppLockProvider` to remove some naming confusion
- Adds overloads to the exception class to make it easier to instantiate.
