### PR TITLE
Add AwaitSync() extension method

### DIFF
--- a/src/Threading/AsyncAwaitExtension.cs
+++ b/src/Threading/AsyncAwaitExtension.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading.Tasks;
+
+namespace RapidCore.Threading
+{
+    public static class AsyncAwaitExtension
+    {
+        /// <summary>
+        /// Extension method that can wait for the async execution of a task and return the result
+        /// </summary>
+        /// <remarks>
+        /// This extension method is particularly useful if you have async code that must be excuted in a
+        /// non async method that cannot be decorated async - like Program.cs or older code / code that must adhere
+        /// no a non async interface
+        ///
+        /// It will also ensure that if exceptions are being thrown that they are flattened such that the "real" exception is thrown
+        /// rather than the usual <see cref="AggregateException" /> thrown by the Task system
+        /// </remarks>
+        /// <param name="awaitable">The async execution that should be awaited in a blocking manner</param>
+        /// <returns>The result of the async operation</returns>
+        public static T AwaitSync<T>(this Task<T> awaitable)
+        {
+            try
+            {
+                awaitable.ConfigureAwait(false);
+                var result = awaitable.Result;
+                return result;
+            }
+            catch (AggregateException ae)
+            {
+                // rethrow the Aggregate exception but flatten it
+                throw ae.Flatten().InnerException;
+            }
+        }
+
+        /// <summary>
+        /// Extension method that can wait for the async execution of a task and return void
+        /// </summary>
+        /// <remarks>
+        /// This extension method is particularly useful if you have async code that must be excuted in a
+        /// non async method that cannot be decorated async - like Program.cs or older code / code that must adhere
+        /// no a non async interface
+        ///
+        /// It will also ensure that if exceptions are being thrown that they are flattened such that the "real" exception is thrown
+        /// rather than the usual <see cref="AggregateException" /> thrown by the Task system
+        /// </remarks>
+        /// <param name="awaitable">The async execution that should be awaited in a blocking manner</param>
+        /// <returns>Nothing</returns>
+        public static void AwaitSync(this Task awaitable)
+        {
+            try
+            {
+                awaitable.ConfigureAwait(false);
+                awaitable.Wait();
+                return;
+            }
+            catch (AggregateException ae)
+            {
+                // rethrow the Aggregate exception but flatten it
+                throw ae.Flatten().InnerException;
+            }
+        }
+    }
+}

--- a/test/unit/Threading/AsyncAwaitExtension.cs
+++ b/test/unit/Threading/AsyncAwaitExtension.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+using RapidCore.Threading;
+using Xunit;
+
+namespace RapidCore.UnitTests.Threading
+{
+    public class AsyncAwaitExtension
+    {
+        public AsyncAwaitExtension()
+        {
+            
+        }
+
+        [Fact]
+        public void AsyncAwait_can_wait_for_op_with_result()
+        {
+            var res = FriendlyAsync().AwaitSync();
+            Assert.Equal(42, res);
+        }
+
+        [Fact]
+        public void AsyncAwait_does_get_root_exception_when_stuff_dies()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => UnfriendlyAsync().AwaitSync());
+            Assert.Equal("Test threw this", ex.Message);
+        }
+
+        [Fact]
+        public void AsyncAwait_can_wait_for_op_with_no_result()
+        {
+            FriendlyWithoutReturnType().AwaitSync();
+            Assert.True(true);
+        }
+
+        [Fact]
+        public void AsyncAwait_does_get_root_exception_on_non_return_type_tasks()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => UnfriendlyWithoutReturnTypeAsync().AwaitSync());
+            Assert.Equal("Arguments are thrown", ex.Message);
+        }
+
+        private async Task<int> FriendlyAsync()
+        {
+            await Task.Delay(10);
+            return 42;
+        }
+
+        private async Task FriendlyWithoutReturnType()
+        {
+            await Task.Delay(10);
+            return;
+        }
+
+        private async Task<int> UnfriendlyAsync()
+        {
+            await Task.Delay(10);
+            throw new InvalidOperationException("Test threw this");
+        }
+
+        private async Task UnfriendlyWithoutReturnTypeAsync()
+        {
+            await Task.Delay(10);
+            throw new ArgumentException("Arguments are thrown");
+        }
+    }
+}


### PR DESCRIPTION
This extension method allows synchronous code to wait for async code,
but without having to decorate the sync method as async Task.

Handy in Program.cs and other code paths that have to remain sync.

Closes https://github.com/rapidcore/issues/issues/6