### PR TITLE
More country stuff

### DIFF
--- a/src/Globalization/CountryIso3166.cs
+++ b/src/Globalization/CountryIso3166.cs
@@ -27,5 +27,21 @@ namespace RapidCore.Globalization
         /// The english name of the country
         /// </summary>
         public virtual string NameEnglish { get; set; }
+
+        /// <summary>
+        /// Does this country have the given country code
+        /// </summary>
+        /// <param name="alpha2OrAlpha3OrNumeric">Country code to check as either alpha-2, alpha-3 or numeric</param>
+        public virtual bool Is(string alpha2OrAlpha3OrNumeric)
+        {
+            if (int.TryParse(alpha2OrAlpha3OrNumeric, out int numeric))
+            {
+                return numeric == CodeNumeric;
+            }
+
+            var uppered = alpha2OrAlpha3OrNumeric.ToUpper();
+
+            return CodeAlpha2.Equals(uppered) || CodeAlpha3.Equals(uppered);
+        }
     }
 }

--- a/src/Globalization/Iso3166Countries.cs
+++ b/src/Globalization/Iso3166Countries.cs
@@ -265,11 +265,17 @@ namespace RapidCore.Globalization
         /// <summary>
         /// Get country by either alpha-2 or alpha-3 code
         /// </summary>
-        /// <param name="alpha2OrAlpha3">Country code in either alpha-2 or alpha-3</param>
+        /// <param name="alpha2OrAlpha3OrNumeric">Country code in either alpha-2, alpha-3 or numeric</param>
         /// <returns>The matching country or null</returns>
-        public virtual CountryIso3166 Get(string alpha2OrAlpha3)
+        public virtual CountryIso3166 Get(string alpha2OrAlpha3OrNumeric)
         {
-            var uppered = alpha2OrAlpha3.ToUpper();
+            // the input could be numeric, but sent in as a string
+            if (int.TryParse(alpha2OrAlpha3OrNumeric, out int numeric))
+            {
+                return Get(numeric);
+            }
+
+            var uppered = alpha2OrAlpha3OrNumeric.ToUpper();
 
             if (uppered.Length == 2)
             {

--- a/src/Globalization/Iso3166Countries.cs
+++ b/src/Globalization/Iso3166Countries.cs
@@ -294,5 +294,23 @@ namespace RapidCore.Globalization
         {
             return countries.FirstOrDefault(x => x.CodeNumeric == numericCountryCode);
         }
+
+        /// <summary>
+        /// Check whether two given country codes refer to the same country
+        /// </summary>
+        /// <param name="aAlpha2OrAlpha3OrNumeric">Country A</param>
+        /// <param name="bAlpha2OrAlpha3OrNumeric">Country B</param>
+        /// <returns>Whether or not the country codes refer to the same country. If one or both country codes are invalid, <c>false</c> is returned.</returns>
+        public virtual bool Matches(string aAlpha2OrAlpha3OrNumeric, string bAlpha2OrAlpha3OrNumeric)
+        {
+            var a = Get(aAlpha2OrAlpha3OrNumeric);
+
+            if (a == default(CountryIso3166))
+            {
+                return false;
+            }
+
+            return a.Is(bAlpha2OrAlpha3OrNumeric);
+        }
     }
 }

--- a/test/unit/Globalization/CountryIso3166Tests.cs
+++ b/test/unit/Globalization/CountryIso3166Tests.cs
@@ -1,0 +1,26 @@
+using RapidCore.Globalization;
+using Xunit;
+
+namespace RapidCore.UnitTests.Globalization
+{
+    public class CountryIso3166Tests
+    {
+        private readonly Iso3166Countries countries;
+
+        public CountryIso3166Tests()
+        {
+            countries = new Iso3166Countries();
+        }
+
+        [Theory]
+        [InlineData("dk", "dk", true)] // same alpha-2
+        [InlineData("dk", "dnk", true)] // same alpha-3
+        [InlineData("dk", "208", true)] // same numeric
+        [InlineData("dk", "se", false)] // not the same
+        [InlineData("dk", "alala", false)] // not even a country
+        public void Is(string countryCode, string isParam, bool expected)
+        {
+            Assert.Equal(expected, countries.Get(countryCode).Is(isParam));
+        }
+    }
+}

--- a/test/unit/Globalization/Iso3166CountriesTests.cs
+++ b/test/unit/Globalization/Iso3166CountriesTests.cs
@@ -55,5 +55,16 @@ namespace RapidCore.UnitTests.Globalization
             Assert.Equal(208, actual.CodeNumeric);
             Assert.Equal("Denmark", actual.NameEnglish);
         }
+
+        [Theory]
+        [InlineData("alala", "dk", false)] // a is invalid
+        [InlineData("dk", "alala", false)] // b is invalid
+        [InlineData("dk", "dk", true)] // use same valid country code, should match
+        [InlineData("dk", "dnk", true)] // same country different country codes, should match
+        [InlineData("dnk", "208", true)] // same country different country codes, should match
+        public void Matches(string theOneToCheck, string theOneItShouldBe, bool expected)
+        {
+            Assert.Equal(expected, countries.Matches(theOneToCheck, theOneItShouldBe));
+        }
     }
 }

--- a/test/unit/Globalization/Iso3166CountriesTests.cs
+++ b/test/unit/Globalization/Iso3166CountriesTests.cs
@@ -33,6 +33,17 @@ namespace RapidCore.UnitTests.Globalization
             Assert.Equal(208, actual.CodeNumeric);
             Assert.Equal("Denmark", actual.NameEnglish);
         }
+
+        [Fact]
+        public void Get_numeric_sentInAsString()
+        {
+            var actual = countries.Get("208");
+            
+            Assert.Equal("DK", actual.CodeAlpha2);
+            Assert.Equal("DNK", actual.CodeAlpha3);
+            Assert.Equal(208, actual.CodeNumeric);
+            Assert.Equal("Denmark", actual.NameEnglish);
+        }
         
         [Fact]
         public void Get_numeric()


### PR DESCRIPTION
Add methods for checking country codes against each other.

You can do this either directly on a country or via the countries class by providing it with two country codes.

Also adds the feature that a numeric country code can be sent in as a string.