### PR TITLE
Add targeting for dotnet 4.6 as well

### DIFF
--- a/src/Configuration/ConfigBase.cs
+++ b/src/Configuration/ConfigBase.cs
@@ -1,3 +1,5 @@
+#if NETSTANDARD1_6
+
 using System;
 using Microsoft.Extensions.Configuration;
 
@@ -32,3 +34,4 @@ namespace RapidCore.Configuration
         }
     }
 }
+#endif

--- a/src/rapidcore.csproj
+++ b/src/rapidcore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <RootNamespace>RapidCore</RootNamespace>
     <Version>0.12.0</Version>
     <Title>RapidCore</Title>


### PR DESCRIPTION
So that the library can truly be used crossplatform.

For now the `ConfigBase` is NOT included in dotnet 4.6 builds
as `IConfigurationRoot` does not exist in fat-dotnet 4.6.