### PR TITLE
Mockable HTTP client

### DIFF
--- a/src/Network/IMockRapidHttpClientTestCase.cs
+++ b/src/Network/IMockRapidHttpClientTestCase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace RapidCore.Network
 {
@@ -17,9 +18,12 @@ namespace RapidCore.Network
 
         /// <summary>
         /// Get the mock response for the given request.
+        ///
+        /// This method is async, to allow for cases where you want
+        /// to delay the response or some other clever thing :)
         /// </summary>
         /// <param name="request">The request to "respond" to</param>
         /// <returns>The response</returns>
-        HttpResponseMessage GetResponse(HttpRequestMessage request);
+        Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request);
     }
 }

--- a/src/Network/IMockRapidHttpClientTestCase.cs
+++ b/src/Network/IMockRapidHttpClientTestCase.cs
@@ -1,0 +1,25 @@
+﻿using System.Net.Http;
+
+namespace RapidCore.Network
+{
+    /// <summary>
+    /// Defines the interface for test cases
+    /// used by <see cref="MockRapidHttpClient"/>
+    /// </summary>
+    public interface IMockRapidHttpClientTestCase
+    {
+        /// <summary>
+        /// Is this the request we are looking for?
+        /// </summary>
+        /// <param name="request">The request to check</param>
+        /// <returns><c>True</c> if the request matches this case, <c>false</c> otherwise.</returns>
+        bool IsMatch(HttpRequestMessage request);
+
+        /// <summary>
+        /// Get the mock response for the given request.
+        /// </summary>
+        /// <param name="request">The request to "respond" to</param>
+        /// <returns>The response</returns>
+        HttpResponseMessage GetResponse(HttpRequestMessage request);
+    }
+}

--- a/src/Network/IRapidHttpClient.cs
+++ b/src/Network/IRapidHttpClient.cs
@@ -1,0 +1,19 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace RapidCore.Network
+{
+    /// <summary>
+    /// Layer on top of <see cref="HttpClient"/> to allow for
+    /// easy-to-understand mocking of responses.
+    /// </summary>
+    public interface IRapidHttpClient
+    {
+        /// <summary>
+        /// Send an async request
+        /// </summary>
+        /// <param name="request">The request</param>
+        /// <returns>The response</returns>
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
+    }
+}

--- a/src/Network/MockRapidHttpClient.cs
+++ b/src/Network/MockRapidHttpClient.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace RapidCore.Network
+{
+    /// <summary>
+    /// Never actually sends requests anywhere. All responses come
+    /// from the provided test cases
+    /// </summary>
+    public class MockRapidHttpClient : IRapidHttpClient
+    {
+        private readonly List<IMockRapidHttpClientTestCase> testCases = new List<IMockRapidHttpClientTestCase>();
+
+        /// <summary>
+        /// "Send" the request - i.e. find a matching test case and
+        /// run it.
+        ///
+        /// Note that the first test case found that matches the request will be used.
+        ///
+        /// If you want a default response, simply add a "return true" test case as the
+        /// last test case. It will then act as a catch-all.
+        /// </summary>
+        /// <param name="request">The request</param>
+        /// <returns>The mock response provided by the matching test case</returns>
+        /// <exception cref="MockRapidHttpClientException">Thrown if no test cases matches</exception>
+        public virtual Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            var testCase = testCases.FirstOrDefault(x => x.IsMatch(request));
+
+            if (testCase == default(IMockRapidHttpClientTestCase))
+            {
+                throw new MockRapidHttpClientException("Could not find a suitable test-case for the request.", request);
+            }
+
+            return Task.FromResult(testCase.GetResponse(request));
+        }
+
+        /// <summary>
+        /// Add a test case
+        /// </summary>
+        /// <param name="testCase">The test case</param>
+        public virtual MockRapidHttpClient AddTestCase(IMockRapidHttpClientTestCase testCase)
+        {
+            testCases.Add(testCase);
+            return this;
+        }
+    }
+}

--- a/src/Network/MockRapidHttpClient.cs
+++ b/src/Network/MockRapidHttpClient.cs
@@ -34,7 +34,7 @@ namespace RapidCore.Network
                 throw new MockRapidHttpClientException("Could not find a suitable test-case for the request.", request);
             }
 
-            return Task.FromResult(testCase.GetResponse(request));
+            return testCase.GetResponseAsync(request);
         }
 
         /// <summary>

--- a/src/Network/MockRapidHttpClientException.cs
+++ b/src/Network/MockRapidHttpClientException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Net.Http;
+
+namespace RapidCore.Network
+{
+    public class MockRapidHttpClientException : Exception
+    {
+        public MockRapidHttpClientException(string message, HttpRequestMessage request)
+            : base(message)
+        {
+            Request = request;
+        }
+
+        public HttpRequestMessage Request { get; set; }
+    }
+}

--- a/src/Network/RealRapidHttpClient.cs
+++ b/src/Network/RealRapidHttpClient.cs
@@ -1,0 +1,28 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace RapidCore.Network
+{
+    /// <summary>
+    /// Actually sends request - no mocking.
+    /// </summary>
+    public class RealRapidHttpClient : IRapidHttpClient
+    {
+        private readonly HttpClient httpClient;
+
+        public RealRapidHttpClient(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+
+        /// <summary>
+        /// Send the request
+        /// </summary>
+        /// <param name="request">The request</param>
+        /// <returns>The response</returns>
+        public virtual Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            return httpClient.SendAsync(request);
+        }
+    }
+}

--- a/test/unit/Network/MockRapidHttpClientTests.cs
+++ b/test/unit/Network/MockRapidHttpClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading.Tasks;
 using FakeItEasy;
 using RapidCore.Network;
 using Xunit;
@@ -63,7 +64,7 @@ namespace RapidCore.UnitTests.Network
             A.CallTo(() => testCase3.IsMatch(request)).Returns(true);
             
             var response = new HttpResponseMessage();
-            A.CallTo(() => testCase2.GetResponse(request)).Returns(response);
+            A.CallTo(() => testCase2.GetResponseAsync(request)).Returns(Task.FromResult(response));
             
             var actual = await client.SendAsync(request);
             

--- a/test/unit/Network/MockRapidHttpClientTests.cs
+++ b/test/unit/Network/MockRapidHttpClientTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Net.Http;
+using FakeItEasy;
+using RapidCore.Network;
+using Xunit;
+
+namespace RapidCore.UnitTests.Network
+{
+    public class MockRapidHttpClientTests
+    {
+        private readonly MockRapidHttpClient client;
+        private readonly IMockRapidHttpClientTestCase testCase1;
+        private readonly IMockRapidHttpClientTestCase testCase2;
+        private readonly IMockRapidHttpClientTestCase testCase3;
+
+        public MockRapidHttpClientTests()
+        {
+            testCase1 = A.Fake<IMockRapidHttpClientTestCase>();
+            testCase2 = A.Fake<IMockRapidHttpClientTestCase>();
+            testCase3 = A.Fake<IMockRapidHttpClientTestCase>();
+            
+            client = new MockRapidHttpClient();
+        }
+
+        [Fact]
+        public async void SendAsync_ThrowsIf_NoTestCasesAtAll()
+        {
+            var request = new HttpRequestMessage();
+            
+            var actual = await Assert.ThrowsAsync<MockRapidHttpClientException>(async () =>
+                await client.SendAsync(request));
+            
+            Assert.Same(request, actual.Request);
+        }
+        
+        [Fact]
+        public async void SendAsync_ThrowsIf_noMatchingTestCases()
+        {
+            var request = new HttpRequestMessage();
+            client
+                .AddTestCase(testCase1)
+                .AddTestCase(testCase2);
+
+            A.CallTo(() => testCase1.IsMatch(request)).Returns(false);
+            A.CallTo(() => testCase2.IsMatch(request)).Returns(false);
+            
+            var actual = await Assert.ThrowsAsync<MockRapidHttpClientException>(async () =>
+                await client.SendAsync(request));
+            
+            Assert.Same(request, actual.Request);
+        }
+        
+        [Fact]
+        public async void SendAsync_returnsResponse_fromFirstMatchingTestCase()
+        {
+            var request = new HttpRequestMessage();
+            client
+                .AddTestCase(testCase1)
+                .AddTestCase(testCase2)
+                .AddTestCase(testCase3);
+
+            A.CallTo(() => testCase1.IsMatch(request)).Returns(false);
+            A.CallTo(() => testCase2.IsMatch(request)).Returns(true);
+            A.CallTo(() => testCase3.IsMatch(request)).Returns(true);
+            
+            var response = new HttpResponseMessage();
+            A.CallTo(() => testCase2.GetResponse(request)).Returns(response);
+            
+            var actual = await client.SendAsync(request);
+            
+            Assert.Same(response, actual);
+        }
+    }
+}


### PR DESCRIPTION
Introduces `RapidCore.Network.IRapidHttpClient` including 2 implementations:

1. `RapidCore.Network.RealRapidHttpClient`, which simply delegates all work to `System.Net.Http.HttpClient`
2. `RapidCore.Network.MockRapidHttpClient`, which maps a given request to a response, using the test cases it has been provided

The case this is meant to support, is that your application needs to talk to an external service somewhere using HTTP. In production this is easy, but in development you might not have those services available (at least not consistently), but you want to be able to run "full-flow" tests with predictable responses. You also do not want to have to make special test code deep in the belly of your codebase.

Our suggestion is that you do something like this:

```csharp
class ExternalServiceClient
{
    public ExternalServiceClient(IRapidHttpClient httpClient) { ... }

    public async Task<...> GetSomethingSpecific(string someId)
    {
        var request = new HttpRequestMessage($"http://example.com/{someId}");
        var response = await httpClient.SendAsync(request);
        ....
    }
}

class ExampleDotComTestCase : IMockRapidHttpClientTestCase
{
    public bool IsMatch(HttpRequestMessage request)
    {
        // look for requests for example.com
        return request.RequestUri.Host.Equals("example.com");
    }

    public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
    {
        // always respond with "bad gateway"
        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway));
    }
}

class ContainerConfiguration
{
    if (config.UseHttpMocking)
    {
        var mockClient = new MockRapidHttpClient();
        mockClient.AddTestCase(new ExampleDotComTestCase());

        container.RegisterAs<IRapidHttpClient>(mockClient);
    }
    else
    {
        container.RegisterAs<IRapidHttpClient>(new RealRapidHttpClient(new HttpClient()));
    }
}
```