### PR TITLE
Fix test assertion for hostname to ip resolver

### DIFF
--- a/test/unit/Network/HostnameToIpResolverTest.cs
+++ b/test/unit/Network/HostnameToIpResolverTest.cs
@@ -20,7 +20,11 @@ namespace RapidCore.UnitTests.Network
         public async Task HostnameToIpResolve_can_fail()
         {
             var resolver = new HostnameToIpResolver();
-            await Assert.ThrowsAsync<SocketException>(async () => await resolver.ResolveToIpv4Async("this-host-is-invalid"));
+            var exception =
+                await Record.ExceptionAsync(async () => await resolver.ResolveToIpv4Async("this-host-is-invalid"));
+            Assert.NotNull(exception);
+            
+            Assert.IsAssignableFrom<SocketException>(exception);
         }
     }
 }


### PR DESCRIPTION
Rather than testing that the caught exception is _of_ type SocketException
we test that it is assignable to this type - the exception thrown on niX
variants inherit from the SocketException but are not that actual type.

Stupid...

This PR closes https://github.com/rapidcore/issues/issues/8