### PR TITLE
Add BaseAddress and Timeout properties to IRapidHttpClient

### DIFF
--- a/src/Network/IRapidHttpClient.cs
+++ b/src/Network/IRapidHttpClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace RapidCore.Network
@@ -15,5 +16,19 @@ namespace RapidCore.Network
         /// <param name="request">The request</param>
         /// <returns>The response</returns>
         Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
+        
+        /// <summary>
+        /// The base address of Uniform Resource Identifier (URI) of the Internet resource used when sending requests.
+        /// 
+        /// <see cref="HttpClient.BaseAddress"/>
+        /// </summary>
+        Uri BaseAddress { get; set; }
+
+        /// <summary>
+        /// The timespan to wait before the request times out.
+        /// 
+        /// <see cref="HttpClient.Timeout"/>
+        /// </summary>
+        TimeSpan Timeout { get; set; }
     }
 }

--- a/src/Network/MockRapidHttpClient.cs
+++ b/src/Network/MockRapidHttpClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -46,5 +47,19 @@ namespace RapidCore.Network
             testCases.Add(testCase);
             return this;
         }
+        
+        /// <summary>
+        /// The base address of Uniform Resource Identifier (URI) of the Internet resource used when sending requests.
+        /// 
+        /// <see cref="HttpClient.BaseAddress"/>
+        /// </summary>
+        public virtual Uri BaseAddress { get; set; }
+
+        /// <summary>
+        /// The timespan to wait before the request times out.
+        /// 
+        /// <see cref="HttpClient.Timeout"/>
+        /// </summary>
+        public virtual TimeSpan Timeout { get; set; }
     }
 }

--- a/src/Network/RealRapidHttpClient.cs
+++ b/src/Network/RealRapidHttpClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace RapidCore.Network
@@ -23,6 +24,28 @@ namespace RapidCore.Network
         public virtual Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
         {
             return httpClient.SendAsync(request);
+        }
+
+        /// <summary>
+        /// The base address of Uniform Resource Identifier (URI) of the Internet resource used when sending requests.
+        /// 
+        /// <see cref="HttpClient.BaseAddress"/>
+        /// </summary>
+        public virtual Uri BaseAddress
+        {
+            get => httpClient.BaseAddress;
+            set => httpClient.BaseAddress = value;
+        }
+
+        /// <summary>
+        /// The timespan to wait before the request times out.
+        /// 
+        /// <see cref="HttpClient.Timeout"/>
+        /// </summary>
+        public virtual TimeSpan Timeout
+        {
+            get => httpClient.Timeout;
+            set => httpClient.Timeout = value;
         }
     }
 }


### PR DESCRIPTION
Adds a couple of properties to the `IRapidHttpClient` that maps directly to the built-in ´HttpClient`.

I left out `MaxResponseContentBufferSize` as I felt this was too specific to the current implementation in `RealRapidHttpClient` that uses `HttpClient`.

Note that in `HttpClient` setting a timeout can also be achieved per request by using a `CancellationTokenSource`.
https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.timeout?view=netcore-1.1

Closes rapidcore/issues#18
