### PR TITLE
Add lockAutoExpireTimeout to IDistributedAppLock Acquire methods

### DIFF
--- a/src/Locking/IDistributedAppLockProvider.cs
+++ b/src/Locking/IDistributedAppLockProvider.cs
@@ -14,22 +14,28 @@ namespace RapidCore.Locking
         ///
         /// If lockWaitTimeout is defined it will wait / retry for the given amount of time before throwing an exception
         /// and giving up on acquiring the lock
+        /// 
+        /// Providing a <paramref name="lockAutoExpireTimeout"/> will enable the distributed app lock provider to automatically
+        /// release stale locks in case the application has crashed and didn't release the lock
         /// </summary>
         /// <exception cref="DistributedAppLockException">Thrown if the lock cannot be acquired</exception>
         /// <param name="lockName">The name of the lock to acquire</param>
         /// <param name="lockWaitTimeout">The time to wait / retry acquiring the lock</param>
-        IDistributedAppLock Acquire(string lockName, TimeSpan? lockWaitTimeout = null);
+        /// <param name="lockAutoExpireTimeout">The amount of time before the lock should automatically be expired</param>
+        IDistributedAppLock Acquire(string lockName, TimeSpan? lockWaitTimeout = null, TimeSpan? lockAutoExpireTimeout = null);
 
-        /// <summary>
-        /// When implemented in a downstream lock class, it will try to acquire the lock in a non-blocking (async) manner
-        ///
-        /// If lockWaitTimeout is defined it will wait / retry for the given amount of time before throwing an exception
-        /// and giving up on acquiring the lock
-        /// </summary>
-        /// <exception cref="DistributedAppLockException">Thrown if the lock cannot be acquired</exception>
-        /// <param name="lockName">The name of the lock to acquire</param>
-        /// <param name="lockWaitTimeout">The time to wait / retry acquiring the lock</param>
+        ///  <summary>
+        ///  When implemented in a downstream lock class, it will try to acquire the lock in a non-blocking (async) manner
+        ///  If lockWaitTimeout is defined it will wait / retry for the given amount of time before throwing an exception
+        ///  and giving up on acquiring the lock
+        /// Providing a <paramref name="lockAutoExpireTimeout"/> will enable the distributed app lock provider to automatically
+        /// release stale locks in case the application has crashed and didn't release the lock
+        ///  </summary>
+        ///  <exception cref="DistributedAppLockException">Thrown if the lock cannot be acquired</exception>
+        ///  <param name="lockName">The name of the lock to acquire</param>
+        ///  <param name="lockWaitTimeout">The time to wait / retry acquiring the lock</param>
+        /// <param name="lockAutoExpireTimeout">The amount of time before the lock should automatically be expired</param>
         /// <returns></returns>
-        Task<IDistributedAppLock> AcquireAsync(string lockName, TimeSpan? lockWaitTimeout = null);
+        Task<IDistributedAppLock> AcquireAsync(string lockName, TimeSpan? lockWaitTimeout = null, TimeSpan? lockAutoExpireTimeout = null);
     }
 }

--- a/src/Locking/NoopDistributedAppLockProvider.cs
+++ b/src/Locking/NoopDistributedAppLockProvider.cs
@@ -14,12 +14,14 @@ namespace RapidCore.Locking
     [Obsolete("This should not be used in real systems", false)]
     public class NoopDistributedAppLockProvider : IDistributedAppLockProvider
     {
-        public virtual IDistributedAppLock Acquire(string lockName, TimeSpan? lockWaitTimeout = null)
+        public virtual IDistributedAppLock Acquire(string lockName, TimeSpan? lockWaitTimeout = null,
+            TimeSpan? lockAutoExpireTimeout = null)
         {
-            return AcquireAsync(lockName, lockWaitTimeout).AwaitSync();
+            return AcquireAsync(lockName, lockWaitTimeout, lockAutoExpireTimeout).AwaitSync();
         }
 
-        public virtual async Task<IDistributedAppLock> AcquireAsync(string lockName, TimeSpan? lockWaitTimeout = null)
+        public virtual async Task<IDistributedAppLock> AcquireAsync(string lockName, TimeSpan? lockWaitTimeout = null,
+            TimeSpan? lockAutoExpireTimeout = null)
         {
             return await Task.FromResult(new NoopDistributedAppLock
             {

--- a/src/Migration/MigrationRunner.cs
+++ b/src/Migration/MigrationRunner.cs
@@ -65,7 +65,7 @@ namespace RapidCore.Migration
             // 3. Run each migration
             // 4. Mark successfully run migrations as completed
             
-            using (await appLocker.AcquireAsync(GetLockName(), TimeSpan.FromSeconds(30)))
+            using (await appLocker.AcquireAsync(GetLockName(), TimeSpan.FromSeconds(30), TimeSpan.MaxValue))
             {
                 logger.LogInformation($"Lock {GetLockName()} acquired");
                 var sw = new Stopwatch();


### PR DESCRIPTION
The purpose of this property, if set, is that implemtors of distributed
app locks shall ask the backing store to expire lock keys after the given
interval, or otherwise implement functionality that will "wipe" leftover
keys after the given interval has expired.