### PR TITLE
Add dotnet target 4.5

### DIFF
--- a/rapidcore.sln
+++ b/rapidcore.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "rapidcore", "src\rapidcore.csproj", "{B1904C1F-55D3-4E30-A237-09E857A9A1C7}"
 EndProject
@@ -8,7 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{2D295025-9
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "unittests", "test\unit\unittests.csproj", "{76976144-B45C-4553-9333-4022384F7A38}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "functionaltests", "test\functional\functionaltests.csproj", "{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "functionaltests", "test\functional\functionaltests.csproj", "{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -46,16 +46,16 @@ Global
 		{76976144-B45C-4553-9333-4022384F7A38}.Release|x86.Build.0 = Release|Any CPU
 		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|x64.ActiveCfg = Debug|x64
-		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|x64.Build.0 = Debug|x64
-		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|x86.ActiveCfg = Debug|x86
-		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|x86.Build.0 = Debug|x86
+		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|x64.Build.0 = Debug|Any CPU
+		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Debug|x86.Build.0 = Debug|Any CPU
 		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|x64.ActiveCfg = Release|x64
-		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|x64.Build.0 = Release|x64
-		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|x86.ActiveCfg = Release|x86
-		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|x86.Build.0 = Release|x86
+		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|x64.ActiveCfg = Release|Any CPU
+		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|x64.Build.0 = Release|Any CPU
+		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|x86.ActiveCfg = Release|Any CPU
+		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -63,5 +63,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{76976144-B45C-4553-9333-4022384F7A38} = {2D295025-9C87-4D6C-ACFC-AD58D8D2EBB8}
 		{0D9F1D66-8532-49B1-AFA2-9FD3CBDA4526} = {2D295025-9C87-4D6C-ACFC-AD58D8D2EBB8}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0E2DFAEC-62E7-4902-B711-910BC82DC26B}
 	EndGlobalSection
 EndGlobal

--- a/src/Migration/Internal/MigrationBuilder.cs
+++ b/src/Migration/Internal/MigrationBuilder.cs
@@ -24,11 +24,19 @@ namespace RapidCore.Migration.Internal
         /// <exception cref="T:System.ArgumentException">stepName</exception>
         public virtual IMigrationBuilder Step(string stepName, Action action)
         {
+#if NET45
+            return Step(stepName, async () =>
+            {
+                action();
+                await Task.FromResult(0);
+            });
+#else
             return Step(stepName, async () =>
             {
                 action();
                 await Task.CompletedTask;
             });
+#endif
         }
         
         /// <inheritdoc />

--- a/src/Migration/MigrationRunner.cs
+++ b/src/Migration/MigrationRunner.cs
@@ -99,7 +99,9 @@ namespace RapidCore.Migration
         /// </summary>
         public virtual async Task DowngradeAsync()
         {
-            await Task.FromException(new NotImplementedException("Downgrade has not been implemented yet. Provide your input in https://github.com/rapidcore/issues/issues/14"));
+            await Task.FromResult(0);
+            throw new NotImplementedException(
+                "Downgrade has not been implemented yet. Provide your input in https://github.com/rapidcore/issues/issues/14");
         }
     }
 }

--- a/src/rapidcore.csproj
+++ b/src/rapidcore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net46;net45</TargetFrameworks>
     <RootNamespace>RapidCore</RootNamespace>
     <Version>0.18.0</Version>
     <Title>RapidCore</Title>
@@ -16,14 +16,25 @@
     <Company>SKARP ApS</Company>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">
+    <DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD1_6</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45'">
+    <DefineConstants>NET45;NETFULL</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="SSH.NET" Version="2016.0.0" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.4.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Environment" />


### PR DESCRIPTION
It turned out to be quite trivial to add dotnet 4.5 target support, so here we go!

One note is that one code branch is now using slightly "uglier" code to be both dotnet 4.5 and 4.6/core compatible, however, I prefer the uglier code that supports all platforms rather than `#if / #else` conditional compilations