### PR TITLE
Switch to the less restrictive IConfiguration interface

### DIFF
--- a/src/core/main/Configuration/ConfigBase.cs
+++ b/src/core/main/Configuration/ConfigBase.cs
@@ -14,9 +14,9 @@ namespace RapidCore.Configuration
     /// </summary>
     public abstract class ConfigBase
     {
-        private readonly IConfigurationRoot configuration;
+        private readonly IConfiguration configuration;
 
-        public ConfigBase(IConfigurationRoot configuration)
+        protected ConfigBase(IConfiguration configuration)
         {
             this.configuration = configuration;
         }


### PR DESCRIPTION
> public interface IConfigurationRoot : Microsoft.Extensions.Configuration.IConfiguration

https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.iconfigurationroot?view=aspnetcore-2.0

The current templates used by `dotnet new` use `IConfiguration` rather than `IConfigurationRoot`, so I think it makes sense to use that as it is less restrictive anyway.

I also made the constructor `protected` as that makes more sense on an abstract class.