### PR TITLE
Nuget fixes

### DIFF
--- a/src/mongo/main/rapidcore.mongo.csproj
+++ b/src/mongo/main/rapidcore.mongo.csproj
@@ -7,11 +7,11 @@
     <Authors>nover</Authors>
     <Description>RapidCore is a collection of dotnet libraries to help you accelerate backend and api development</Description>
     <PackageTags>dotnet core;core;rapidcore;business;business logic;help;helpers;library;mongo</PackageTags>
-    <PackageProjectUrl>https://github.com/rapidcore/rapidcore.mongo/</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/rapidcore/rapidcore.mongo/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/rapidcore/rapidcore/</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/rapidcore/rapidcore/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/rapidcore/rapidcore.mongo/</RepositoryUrl>
+    <RepositoryUrl>https://github.com/rapidcore/rapidcore/</RepositoryUrl>
     <PackageId>RapidCore.Mongo</PackageId>
     <Company>SKARP ApS</Company>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/postgresql/main/rapidcore.postgresql.csproj
+++ b/src/postgresql/main/rapidcore.postgresql.csproj
@@ -4,6 +4,18 @@
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <RootNamespace>RapidCore.PostgreSql</RootNamespace>
     <Version>0.20.0</Version>
+    <Title>RapidCore.PostgreSql</Title>
+    <Authors>nover</Authors>
+    <Description>RapidCore is a collection of dotnet libraries to help you accelerate backend and api development</Description>
+    <PackageTags>dotnet core;core;rapidcore;business;business logic;help;helpers;library;postgresql</PackageTags>
+    <PackageProjectUrl>https://github.com/rapidcore/rapidcore/</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/rapidcore/rapidcore/master/LICENSE</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/rapidcore/rapidcore/</RepositoryUrl>
+    <PackageId>RapidCore.PostgreSql</PackageId>
+    <Company>SKARP ApS</Company>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/redis/main/rapidcore.redis.csproj
+++ b/src/redis/main/rapidcore.redis.csproj
@@ -7,11 +7,11 @@
     <Authors>nover</Authors>
     <Description>RapidCore.Redis is redis dependend code for the RapidCore library</Description>
     <PackageTags>dotnet core;core;rapidcore;business;business logic;help;helpers;library;redis;lock;locking;distributed locking;</PackageTags>
-    <PackageProjectUrl>https://github.com/rapidcore/rapidcore.redis/</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/rapidcore/rapidcore.redis/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/rapidcore/rapidcore/</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/rapidcore/rapidcore/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/rapidcore/rapidcore.redis/</RepositoryUrl>
+    <RepositoryUrl>https://github.com/rapidcore/rapidcore/</RepositoryUrl>
     <PackageId>RapidCore.Redis</PackageId>
     <Company>SKARP ApS</Company>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/xunit/main/rapidcore.xunit.csproj
+++ b/src/xunit/main/rapidcore.xunit.csproj
@@ -8,11 +8,11 @@
     <Authors>nover</Authors>
     <Description>RapidCore.Xunit is a collection of tools to speed up your xunit test coding process</Description>
     <PackageTags>dotnet core;core;rapidcore;business;business logic;help;helpers;library;test;</PackageTags>
-    <PackageProjectUrl>https://github.com/rapidcore/rapidcore.xunit/</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/rapidcore/rapidcore.xunit/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/rapidcore/rapidcore/</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/rapidcore/rapidcore/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/rapidcore/rapidcore.xunit/</RepositoryUrl>
+    <RepositoryUrl>https://github.com/rapidcore/rapidcore/</RepositoryUrl>
     <PackageId>RapidCore.Xunit</PackageId>
     <Company>SKARP ApS</Company>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
We forgot to update the urls used by NuGet, when we merged the repositories.

We also forgot to add the NuGet information to the new PostgreSql package.