### PR TITLE
Add support for ConfigBase.Get<MyEnum>(...)

### DIFF
--- a/src/core/main/Configuration/ConfigBase.cs
+++ b/src/core/main/Configuration/ConfigBase.cs
@@ -1,6 +1,7 @@
 #if NETSTANDARD1_6
 
 using System;
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 
 namespace RapidCore.Configuration
@@ -28,6 +29,21 @@ namespace RapidCore.Configuration
             if (string.IsNullOrEmpty(value))
             {
                 return defaultValue;
+            }
+
+            if (typeof(T).GetTypeInfo().IsEnum)
+            {
+                // try..catch is not as pretty as Enum.TryParse, but
+                // TryParse requires T to be non-nullable, which is
+                // not a constraint for us
+                try
+                {
+                    return (T)Enum.Parse(typeof(T), value, true);
+                }
+                catch (Exception)
+                {
+                    return defaultValue;
+                }
             }
 
             return (T)Convert.ChangeType(value, typeof(T));

--- a/src/core/test-unit/Configuration/ConfigBaseTests.cs
+++ b/src/core/test-unit/Configuration/ConfigBaseTests.cs
@@ -19,7 +19,11 @@ namespace RapidCore.UnitTests.Configuration
                     { "int", "3" },
                     { "int_zero", "0" },
                     { "section:section-1", "s1 from config" },
-                    { "section:subsection:subsection-1", "subsection 1 from config"}
+                    { "section:subsection:subsection-1", "subsection 1 from config"},
+                    { "enum", "One" },
+                    { "enum_null", null },
+                    { "enum_empty", string.Empty },
+                    { "enum_invalid", "NotAValidValue" }
                 });
 
             config = new MyTestConfig(builder.Build());
@@ -106,6 +110,36 @@ namespace RapidCore.UnitTests.Configuration
         {
             Assert.Equal("subsection 1 from config", config.Get<string>("section:subsection:subsection-1", "default"));
         }
+
+        [Fact]
+        public void Get_Enum()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("enum", MyTestConfigThing.Zero));
+        }
+
+        [Fact]
+        public void Get_Enum_Default_IfNull()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("enum_null", MyTestConfigThing.One));
+        }
+
+        [Fact]
+        public void Get_Enum_Default_IfEmpty()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("enum_empty", MyTestConfigThing.One));
+        }
+
+        [Fact]
+        public void Get_Enum_Default_IfUndefined()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("does_not_exist_coz_that_would_be_weird", MyTestConfigThing.One));
+        }
+        
+        [Fact]
+        public void Get_Enum_Default_IfInvalidValue()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("enum_invalid", MyTestConfigThing.One));
+        }
         
         
 
@@ -128,6 +162,12 @@ namespace RapidCore.UnitTests.Configuration
             {
                 return configuration.GetSection(key);
             }
+        }
+
+        private enum MyTestConfigThing
+        {
+            Zero = 0,
+            One = 1
         }
         #endregion
     }


### PR DESCRIPTION
`ConfigBase.Get<T>(...)` did not support `T` being an `Enum`. Now it does :)