### PR TITLE
Add prerelease pipeline for merges on master

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -61,7 +61,7 @@ if ( (!$Env:APPVEYOR_REPO_TAG) -or ( $Env:APPVEYOR_REPO_TAG -ne "true") ) {
 ##
 # Update all packages to use nuget reference and pack them up as nugets
 ##
-$projectsToBuild = '.\src\core\main\rapidcore.csproj', '.\src\google-cloud\main\rapidcore.google-cloud.csproj', '.\src\mongo\main\rapidcore.mongo.csproj', '.\src\postgresql\main\rapidcore.postgresql.csproj', '.\src\redis\main\rapidcore.redis.csproj', '.\src\xunit\main\rapidcore.xunit.csproj'
+$mainProjects = '.\src\core\main\rapidcore.csproj', '.\src\google-cloud\main\rapidcore.google-cloud.csproj', '.\src\mongo\main\rapidcore.mongo.csproj', '.\src\postgresql\main\rapidcore.postgresql.csproj', '.\src\redis\main\rapidcore.redis.csproj', '.\src\xunit\main\rapidcore.xunit.csproj'
 
 foreach ($project in $mainProjects) {
     Use-NuGetReference $project $version

--- a/Build.ps1
+++ b/Build.ps1
@@ -12,8 +12,8 @@
 function Exec {
     [CmdletBinding()]
     param(
-        [Parameter(Position=0,Mandatory=1)][scriptblock]$cmd,
-        [Parameter(Position=1,Mandatory=0)][string]$errorMessage = ($msgs.error_bad_command -f $cmd)
+        [Parameter(Position = 0, Mandatory = 1)][scriptblock]$cmd,
+        [Parameter(Position = 1, Mandatory = 0)][string]$errorMessage = ($msgs.error_bad_command -f $cmd)
     )
     & $cmd
     if ($lastexitcode -ne 0) {
@@ -32,19 +32,17 @@ function Use-NuGetReference {
     (Get-Content $pathToCsproj).replace($localReference, $nugetReference) | Set-Content $pathToCsproj
 }
 
-if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
+if (Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
 
 exec { & dotnet restore }
 
 exec { & dotnet build -c Release }
 
-exec { & dotnet test '.\src\core\test-unit\unittests.csproj' -c Release }
-exec { & dotnet test '.\src\google-cloud\test-unit\unittests.csproj' -c Release }
-exec { & dotnet test '.\src\mongo\test-unit\unittests.csproj' -c Release }
-exec { & dotnet test '.\src\postgresql\test-unit\unittests.csproj' -c Release }
-exec { & dotnet test '.\src\redis\test-unit\unittests.csproj' -c Release }
-exec { & dotnet test '.\src\xunit\test-unit\unittests.csproj' -c Release }
+$testProjects = '.\src\core\test-unit\unittests.csproj', '.\src\google-cloud\test-unit\unittests.csproj', '.\src\mongo\test-unit\unittests.csproj', '.\src\postgresql\test-unit\unittests.csproj', '.\src\redis\test-unit\unittests.csproj', '.\src\xunit\test-unit\unittests.csproj'
 
+foreach ($testProject in $testProjects) {
+    exec { & dotnet test $testProject -c Release }
+}
 
 ##
 # Replace local references to RapidCore with NuGet references

--- a/Build.ps1
+++ b/Build.ps1
@@ -45,7 +45,7 @@ foreach ($testProject in $testProjects) {
 }
 
 ##
-# Replace local references to RapidCore with NuGet references
+# Get current version of project and append commit count, if we are not building a tag (thus creating a pre-release)
 ##
 $revCount = & git rev-list HEAD --count | Out-String
 
@@ -59,7 +59,7 @@ if ( (!$Env:APPVEYOR_REPO_TAG) -or ( $Env:APPVEYOR_REPO_TAG -ne "true") ) {
 }
 
 ##
-# Update all packages to use nuget reference and pack them
+# Update all packages to use nuget reference and pack them up as nugets
 ##
 $projectsToBuild = '.\src\core\main\rapidcore.csproj', '.\src\google-cloud\main\rapidcore.google-cloud.csproj', '.\src\mongo\main\rapidcore.mongo.csproj', '.\src\postgresql\main\rapidcore.postgresql.csproj', '.\src\redis\main\rapidcore.redis.csproj', '.\src\xunit\main\rapidcore.xunit.csproj'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,5 @@ deploy:
   api_key:
     secure: O2aKtP6hbwJ7WLPp9s5GcTsOu/OiNL3Zfpuk1w7JjQAQPbT4P3JGD0FsrusyaYrc
   on:
+    branch: master
     appveyor_repo_tag: true


### PR DESCRIPTION
This PR updates the appveyor build pipeline so that

1. Builds on master are released to nuget as `prerelease` packages
1. The `prerelease` version number is made up of: `$packageVersion-preview-$gitCommitCount`. `$packageVersion` is whatever is stored in the csproj `<Version>` tag, e.g: `0.21.0-preview-530`
1. Makes the `Build.ps1` script a bit terser by removing duplicated code.

Also closes #53 