### PR TITLE
Bump patch on preview release

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -51,12 +51,14 @@ $revCount = & git rev-list HEAD --count | Out-String
 
 Set-Location .\src\core\main
 $version = & dotnet version --output-format=json | ConvertFrom-Json | Select-Object -ExpandProperty currentVersion
-Set-Location ..\..\..\
 
-# If we are not building a tag, update the version to include a version suffix
+# If we are not building a tag, update the version to include a version suffix and a minor bump
 if ( (!$Env:APPVEYOR_REPO_TAG) -or ( $Env:APPVEYOR_REPO_TAG -ne "true") ) {
+    $version = & dotnet version --output-format=json --dry-run patch | ConvertFrom-Json | Select-Object -ExpandProperty newVersion
     $version = "$($version)-preview-$($revCount)".Trim()
 }
+
+Set-Location ..\..\..\
 
 ##
 # Update all packages to use nuget reference and pack them up as nugets

--- a/src/core/main/rapidcore.csproj
+++ b/src/core/main/rapidcore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="SSH.NET" Version="2016.0.0" />
 
-    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.6.0" />
+    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.7.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net45'">

--- a/src/mongo/main/rapidcore.mongo.csproj
+++ b/src/mongo/main/rapidcore.mongo.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="MongoDB.Driver.Core" Version="2.4.4" />
     <PackageReference Include="ServiceStack.Text.Core" Version="1.0.43" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.6.0" />
+    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\main\rapidcore.csproj" />

--- a/src/postgresql/main/rapidcore.postgresql.csproj
+++ b/src/postgresql/main/rapidcore.postgresql.csproj
@@ -20,7 +20,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\core\main\rapidcore.csproj" />
-    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.6.0" />
+    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/redis/main/rapidcore.redis.csproj
+++ b/src/redis/main/rapidcore.redis.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.4" />
-    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.6.0" />
+    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.7.0" />
   </ItemGroup>
   
   

--- a/src/xunit/main/rapidcore.xunit.csproj
+++ b/src/xunit/main/rapidcore.xunit.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
-    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.6.0" />
+    <DotNetCliToolReference Include="dotnet-version-cli" Version="0.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\main\rapidcore.csproj" />


### PR DESCRIPTION
This PR updates the preview release pipeline so that the patch version of the packages are bumped - this way the preview packages should be listed as "newer' than the current stable on nuget.