### PR TITLE
Resolve 78: Make it possible to ask the DatastoreConnection/ORM for the name to use for a specific property

### DIFF
--- a/src/google-cloud/main/Datastore/DatastoreConnection.cs
+++ b/src/google-cloud/main/Datastore/DatastoreConnection.cs
@@ -47,6 +47,11 @@ namespace RapidCore.GoogleCloud.Datastore
         public virtual DatastoreDb DatastoreDb => datastoreDb;
 
         /// <summary>
+        /// The underlying ORM
+        /// </summary>
+        public virtual DatastoreOrm Orm => orm;
+
+        /// <summary>
         /// Get the kind of a POCO
         ///
         /// This is meant as a convenience for consumers who might be

--- a/src/google-cloud/main/Datastore/DatastoreOrm.cs
+++ b/src/google-cloud/main/Datastore/DatastoreOrm.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
 using Google.Cloud.Datastore.V1;
 using RapidCore.GoogleCloud.Datastore.ReflectionBased;
 
@@ -112,6 +114,31 @@ namespace RapidCore.GoogleCloud.Datastore
         public virtual TPoco EntityToPoco<TPoco>(Entity entity) where TPoco : new()
         {
             return pocoFactory.FromEntity<TPoco>(entity);
+        }
+
+        /// <summary>
+        /// Get the name of the Datastore entity value for a given property
+        /// </summary>
+        /// <param name="propertySelectionExpression"></param>
+        /// <typeparam name="T">The type you are selecting from</typeparam>
+        /// <exception cref="ArgumentException">Thrown if the expression does not point to a property on the given type</exception>
+        public virtual string GetValueName<T>(Expression<Func<T, object>> propertySelectionExpression)
+        {
+            var expr = propertySelectionExpression.Body as MemberExpression;
+
+            if (expr == null)
+            {
+                throw new ArgumentException("The given expression does not point to a member", nameof(propertySelectionExpression));
+            }
+
+            var prop = expr.Member as PropertyInfo;
+
+            if (prop == null)
+            {
+                throw new ArgumentException("The given expression does not point to a property", nameof(propertySelectionExpression));
+            }
+
+            return reflector.GetValueName(prop);
         }
     }
 }

--- a/src/google-cloud/test-unit/Datastore/DatastoreOrmTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreOrmTests.cs
@@ -4,7 +4,7 @@ using Google.Cloud.Datastore.V1;
 using RapidCore.GoogleCloud.Datastore;
 using Xunit;
 
-namespace unittests.Datestore
+namespace unittests.Datastore
 {
     public class DatastoreOrmTests
     {

--- a/src/google-cloud/test-unit/Datastore/DatastoreOrmTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreOrmTests.cs
@@ -57,8 +57,57 @@ namespace unittests.Datastore
             Assert.Same(entity, actual);
         }
 
+        [Fact]
+        public void GetValueName_works_given_a_property()
+        {
+            var actual = orm.GetValueName<ValueNameVictim>(x => x.MyProperty);
+            
+            Assert.Equal("MyProperty", actual);
+        }
+        
+        [Fact]
+        public void GetValueName_throws_ifExpression_IsWrongType()
+        {
+            var actual = Record.Exception(() => orm.GetValueName<ValueNameVictim>(x => x.MyProperty.Equals("horse")));
+
+            Assert.IsType<ArgumentException>(actual);
+            Assert.StartsWith("The given expression does not point to a member", actual.Message);
+        }
+        
+        [Fact]
+        public void GetValueName_throws_ifExpression_doesNotPointToAProperty()
+        {
+            var actual = Record.Exception(() => orm.GetValueName<ValueNameVictim>(x => x.SomeField));
+
+            Assert.IsType<ArgumentException>(actual);
+            Assert.StartsWith("The given expression does not point to a property", actual.Message);
+        }
+        
+        [Fact]
+        public void GetValueName_1_level_only()
+        {
+            var actual = Record.Exception(() => orm.GetValueName<ValueNameVictim>(x => x.TheDeeper.DangerIs));
+
+            Assert.IsType<ArgumentException>(actual);
+            Assert.StartsWith("The given expression does not point to a member", actual.Message);
+        }
+
         #region POCOs
         public class Bee {}
+        
+        public class ValueNameVictim
+        {
+            public string SomeField;
+            
+            public string MyProperty { get; set; }
+            
+            public Deeper TheDeeper { get; set; }
+        }
+        
+        public class Deeper
+        {
+            public int DangerIs => 23;
+        }
         #endregion
     }
 }

--- a/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/GetContentPropertiesTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/GetContentPropertiesTests.cs
@@ -3,7 +3,7 @@ using RapidCore;
 using RapidCore.GoogleCloud.Datastore;
 using Xunit;
 
-namespace unittests.Datestore.DatastoreReflectorTests
+namespace unittests.Datastore.DatastoreReflectorTests
 {
     public class GetContentPropertiesTests
     {

--- a/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/GetIdValueTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/GetIdValueTests.cs
@@ -3,7 +3,7 @@ using RapidCore;
 using RapidCore.GoogleCloud.Datastore;
 using Xunit;
 
-namespace unittests.Datestore.DatastoreReflectorTests
+namespace unittests.Datastore.DatastoreReflectorTests
 {
     public class GetIdValueTests
     {

--- a/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/GetKindTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/GetKindTests.cs
@@ -2,7 +2,7 @@
 using RapidCore.GoogleCloud.Datastore;
 using Xunit;
 
-namespace unittests.Datestore.DatastoreReflectorTests
+namespace unittests.Datastore.DatastoreReflectorTests
 {
     public class GetKindTests
     {

--- a/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/GetValueNameTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/GetValueNameTests.cs
@@ -2,7 +2,7 @@
 using RapidCore.GoogleCloud.Datastore;
 using Xunit;
 
-namespace unittests.Datestore.DatastoreReflectorTests
+namespace unittests.Datastore.DatastoreReflectorTests
 {
     public class GetValueNameTests
     {

--- a/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/SetIdValueTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreReflectorTests/SetIdValueTests.cs
@@ -3,7 +3,7 @@ using Google.Cloud.Datastore.V1;
 using RapidCore.GoogleCloud.Datastore;
 using Xunit;
 
-namespace unittests.Datestore.DatastoreReflectorTests
+namespace unittests.Datastore.DatastoreReflectorTests
 {
     public class SetIdValueTests
     {

--- a/src/google-cloud/test-unit/Datastore/ReflectionBased/Internal/EntityValueFactoryTests.cs
+++ b/src/google-cloud/test-unit/Datastore/ReflectionBased/Internal/EntityValueFactoryTests.cs
@@ -9,7 +9,7 @@ using RapidCore.GoogleCloud.Datastore;
 using RapidCore.GoogleCloud.Datastore.ReflectionBased.Internal;
 using Xunit;
 
-namespace unittests.Datestore.ReflectionBased.Internal
+namespace unittests.Datastore.ReflectionBased.Internal
 {
     public class EntityValueFactoryTests
     {

--- a/src/google-cloud/test-unit/Datastore/ReflectionBased/Internal/PocoValueFactoryTests.cs
+++ b/src/google-cloud/test-unit/Datastore/ReflectionBased/Internal/PocoValueFactoryTests.cs
@@ -9,7 +9,7 @@ using RapidCore.GoogleCloud.Datastore.ReflectionBased.Internal;
 using Xunit;
 using Value = Google.Cloud.Datastore.V1.Value;
 
-namespace unittests.Datestore.ReflectionBased.Internal
+namespace unittests.Datastore.ReflectionBased.Internal
 {
     public class PocoValueFactoryTests
     {

--- a/src/google-cloud/test-unit/Datastore/ReflectionBased/ReflectionBasedEntityFactoryTests.cs
+++ b/src/google-cloud/test-unit/Datastore/ReflectionBased/ReflectionBasedEntityFactoryTests.cs
@@ -7,7 +7,7 @@ using RapidCore.GoogleCloud.Datastore;
 using RapidCore.GoogleCloud.Datastore.ReflectionBased;
 using Xunit;
 
-namespace unittests.Datestore.ReflectionBased
+namespace unittests.Datastore.ReflectionBased
 {
     public class ReflectionBasedEntityFactoryTests
     {


### PR DESCRIPTION
This adds `DatastoreOrm.GetValueName(Expression)` which allows the caller to select the property to get the name for, using an Expression.

Also, the `DatastoreConnection.Orm` getter is added, which exposes the underlying ORM, so it can be used when building up complex queries.

Oh yeah, and it also fixes a typo in the namespace of the unit tests :)