### PR TITLE
Resolve 81: Add workaround for Datastore emulator bug

### DIFF
--- a/src/google-cloud/test-functional/Datastore/DatastoreConnection/DeleteTests.cs
+++ b/src/google-cloud/test-functional/Datastore/DatastoreConnection/DeleteTests.cs
@@ -8,69 +8,81 @@ namespace functionaltests.Datastore.DatastoreConnection
         [Fact]
         public async void Delete_long()
         {
-            EnsureEmptyKind("TheDeleter");
-            
-            Insert(new Entity
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Key = GetKey("TheDeleter", 5),
-                ["String"] = "hello"
+                EnsureEmptyKind("TheDeleter");
+
+                Insert(new Entity
+                {
+                    Key = GetKey("TheDeleter", 5),
+                    ["String"] = "hello"
+                });
+
+                await connection.DeleteAsync<TheDeleter>(5);
+
+                var all = GetAll("TheDeleter");
+                Assert.Empty(all);
             });
-
-            await connection.DeleteAsync<TheDeleter>(5);
-
-            var all = GetAll("TheDeleter");
-            Assert.Empty(all);
         }
         
         [Fact]
         public async void Delete_string()
         {
-            EnsureEmptyKind("TheDeleter");
-            
-            Insert(new Entity
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Key = GetKey("TheDeleter", "5"),
-                ["String"] = "hello"
+                EnsureEmptyKind("TheDeleter");
+
+                Insert(new Entity
+                {
+                    Key = GetKey("TheDeleter", "5"),
+                    ["String"] = "hello"
+                });
+
+                await connection.DeleteAsync<TheDeleter>("5");
+
+                var all = GetAll("TheDeleter");
+                Assert.Empty(all);
             });
-
-            await connection.DeleteAsync<TheDeleter>("5");
-
-            var all = GetAll("TheDeleter");
-            Assert.Empty(all);
         }
         
         [Fact]
         public async void Delete_long_kind()
         {
-            EnsureEmptyKind("TheDeleter");
-            
-            Insert(new Entity
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Key = GetKey("TheDeleter", 5),
-                ["String"] = "hello"
+                EnsureEmptyKind("TheDeleter");
+
+                Insert(new Entity
+                {
+                    Key = GetKey("TheDeleter", 5),
+                    ["String"] = "hello"
+                });
+
+                await connection.DeleteAsync(5, "TheDeleter");
+
+                var all = GetAll("TheDeleter");
+                Assert.Empty(all);
             });
-
-            await connection.DeleteAsync(5, "TheDeleter");
-
-            var all = GetAll("TheDeleter");
-            Assert.Empty(all);
         }
         
         [Fact]
         public async void Delete_string_kind()
         {
-            EnsureEmptyKind("TheDeleter");
-            
-            Insert(new Entity
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Key = GetKey("TheDeleter", "5"),
-                ["String"] = "hello"
+                EnsureEmptyKind("TheDeleter");
+
+                Insert(new Entity
+                {
+                    Key = GetKey("TheDeleter", "5"),
+                    ["String"] = "hello"
+                });
+
+                await connection.DeleteAsync("5", "TheDeleter");
+
+                var all = GetAll("TheDeleter");
+                Assert.Empty(all);
             });
-
-            await connection.DeleteAsync("5", "TheDeleter");
-
-            var all = GetAll("TheDeleter");
-            Assert.Empty(all);
         }
 
         #region POCOs

--- a/src/google-cloud/test-functional/Datastore/DatastoreConnection/InsertAndLoadTests.cs
+++ b/src/google-cloud/test-functional/Datastore/DatastoreConnection/InsertAndLoadTests.cs
@@ -18,26 +18,29 @@ namespace functionaltests.Datastore.DatastoreConnection
         [Fact]
         public async void CanInsert()
         {
-            EnsureEmptyKind("DasPoco");
-            
-            var n1 = new Nested();
-            var n2 = new Nested {Other = n1};
-            var n3 = new Nested {Other = n2};
-            var n4 = new Nested {Other = n3};
-
-            var poco = new DasPoco
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = Guid.NewGuid(),
-                Complex = new Sub(),
-                Nesting = n4
-            };
+                EnsureEmptyKind("DasPoco");
 
-            await connection.InsertAsync(poco, "DasPoco");
+                var n1 = new Nested();
+                var n2 = new Nested {Other = n1};
+                var n3 = new Nested {Other = n2};
+                var n4 = new Nested {Other = n3};
 
-            var all = GetAll("DasPoco");
-            
-            Assert.Equal(1, all.Count);
-            Assert.Equal(poco.Id.ToString(), all[0].Key.Path[0].Name);
+                var poco = new DasPoco
+                {
+                    Id = Guid.NewGuid(),
+                    Complex = new Sub(),
+                    Nesting = n4
+                };
+
+                await connection.InsertAsync(poco, "DasPoco");
+
+                var all = GetAll("DasPoco");
+
+                Assert.Equal(1, all.Count);
+                Assert.Equal(poco.Id.ToString(), all[0].Key.Path[0].Name);
+            });
         }
         #endregion
 
@@ -45,77 +48,89 @@ namespace functionaltests.Datastore.DatastoreConnection
         [Fact]
         public async void GetByIdAsync_long()
         {
-            EnsureEmptyKind("NumericIdPoco");
-            
-            var poco = new NumericIdPoco
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = random.Next(1, int.MaxValue),
-                String = Guid.NewGuid().ToString()
-            };
+                EnsureEmptyKind("NumericIdPoco");
 
-            await connection.InsertAsync(poco);
+                var poco = new NumericIdPoco
+                {
+                    Id = random.Next(1, int.MaxValue),
+                    String = Guid.NewGuid().ToString()
+                };
 
-            var actual = await connection.GetByIdOrDefaultAsync<NumericIdPoco>(poco.Id);
-            
-            Assert.Equal(poco.Id, actual.Id);
-            Assert.Equal(poco.String, actual.String);
+                await connection.InsertAsync(poco);
+
+                var actual = await connection.GetByIdOrDefaultAsync<NumericIdPoco>(poco.Id);
+
+                Assert.Equal(poco.Id, actual.Id);
+                Assert.Equal(poco.String, actual.String);
+            });
         }
         
         [Fact]
         public async void GetByIdAsync_long_kind()
         {
-            EnsureEmptyKind("GetByIdAsync_long_kind");
-            
-            var poco = new NumericIdPoco
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = random.Next(1, int.MaxValue),
-                String = Guid.NewGuid().ToString()
-            };
+                EnsureEmptyKind("GetByIdAsync_long_kind");
 
-            await connection.InsertAsync(poco, "GetByIdAsync_long_kind");
+                var poco = new NumericIdPoco
+                {
+                    Id = random.Next(1, int.MaxValue),
+                    String = Guid.NewGuid().ToString()
+                };
 
-            var actual = await connection.GetByIdOrDefaultAsync<NumericIdPoco>(poco.Id, "GetByIdAsync_long_kind");
-            
-            Assert.Equal(poco.Id, actual.Id);
-            Assert.Equal(poco.String, actual.String);
+                await connection.InsertAsync(poco, "GetByIdAsync_long_kind");
+
+                var actual = await connection.GetByIdOrDefaultAsync<NumericIdPoco>(poco.Id, "GetByIdAsync_long_kind");
+
+                Assert.Equal(poco.Id, actual.Id);
+                Assert.Equal(poco.String, actual.String);
+            });
         }
         
         [Fact]
         public async void GetByIdAsync_string()
         {
-            EnsureEmptyKind("StringIdPoco");
-            
-            var poco = new StringIdPoco
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = Guid.NewGuid().ToString(),
-                String = Guid.NewGuid().ToString()
-            };
+                EnsureEmptyKind("StringIdPoco");
 
-            await connection.InsertAsync(poco);
+                var poco = new StringIdPoco
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    String = Guid.NewGuid().ToString()
+                };
 
-            var actual = await connection.GetByIdOrDefaultAsync<StringIdPoco>(poco.Id);
-            
-            Assert.Equal(poco.Id, actual.Id);
-            Assert.Equal(poco.String, actual.String);
+                await connection.InsertAsync(poco);
+
+                var actual = await connection.GetByIdOrDefaultAsync<StringIdPoco>(poco.Id);
+
+                Assert.Equal(poco.Id, actual.Id);
+                Assert.Equal(poco.String, actual.String);
+            });
         }
         
         [Fact]
         public async void GetByIdAsync_string_kind()
         {
-            EnsureEmptyKind("GetByIdAsync_string_kind");
-            
-            var poco = new StringIdPoco
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = Guid.NewGuid().ToString(),
-                String = Guid.NewGuid().ToString()
-            };
+                EnsureEmptyKind("GetByIdAsync_string_kind");
 
-            await connection.InsertAsync(poco, "GetByIdAsync_string_kind");
+                var poco = new StringIdPoco
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    String = Guid.NewGuid().ToString()
+                };
 
-            var actual = await connection.GetByIdOrDefaultAsync<StringIdPoco>(poco.Id, "GetByIdAsync_string_kind");
-            
-            Assert.Equal(poco.Id, actual.Id);
-            Assert.Equal(poco.String, actual.String);
+                await connection.InsertAsync(poco, "GetByIdAsync_string_kind");
+
+                var actual = await connection.GetByIdOrDefaultAsync<StringIdPoco>(poco.Id, "GetByIdAsync_string_kind");
+
+                Assert.Equal(poco.Id, actual.Id);
+                Assert.Equal(poco.String, actual.String);
+            });
         }
         #endregion
         

--- a/src/google-cloud/test-functional/Datastore/DatastoreConnection/QueryTests.cs
+++ b/src/google-cloud/test-functional/Datastore/DatastoreConnection/QueryTests.cs
@@ -51,83 +51,98 @@ namespace functionaltests.Datastore.DatastoreConnection
         [Fact]
         public async void Query_query_withKindSet()
         {
-            PrepareData("DonkeyDiamonds");
-            
-            var actual = await connection.Query<Full>(new Query("DonkeyDiamonds")
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Filter = Filter.LessThanOrEqual("X", new Value {IntegerValue = 4})
+                PrepareData("DonkeyDiamonds");
+
+                var actual = await connection.Query<Full>(new Query("DonkeyDiamonds")
+                {
+                    Filter = Filter.LessThanOrEqual("X", new Value {IntegerValue = 4})
+                });
+
+                Assert.Equal(3, actual.Count);
+                Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
+                Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
+                Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
             });
-            
-            Assert.Equal(3, actual.Count);
-            Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
-            Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
-            Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
         }
         
         [Fact]
         public async void Query_query_withoutSettingKind()
         {
-            PrepareData("Full");
-            
-            var actual = await connection.Query<Full>(new Query
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Filter = Filter.LessThanOrEqual("X", new Value {IntegerValue = 4})
+                PrepareData("Full");
+
+                var actual = await connection.Query<Full>(new Query
+                {
+                    Filter = Filter.LessThanOrEqual("X", new Value {IntegerValue = 4})
+                });
+
+                Assert.Equal(3, actual.Count);
+                Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
+                Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
+                Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
             });
-            
-            Assert.Equal(3, actual.Count);
-            Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
-            Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
-            Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
         }
         
         [Fact]
         public async void Query_query_kind()
         {
-            PrepareData("BagOfBaguettes");
-            
-            var actual = await connection.Query<Full>(new Query
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Filter = Filter.LessThanOrEqual("X", new Value {IntegerValue = 4})
-            }, "BagOfBaguettes");
-            
-            Assert.Equal(3, actual.Count);
-            Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
-            Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
-            Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
+                PrepareData("BagOfBaguettes");
+
+                var actual = await connection.Query<Full>(new Query
+                {
+                    Filter = Filter.LessThanOrEqual("X", new Value {IntegerValue = 4})
+                }, "BagOfBaguettes");
+
+                Assert.Equal(3, actual.Count);
+                Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
+                Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
+                Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
+            });
         }
         
         [Fact]
         public async void Query_gql()
         {
-            PrepareData("BagOfBaguettes");
-            
-            var actual = await connection.Query<Full>(new GqlQuery
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                AllowLiterals = true,
-                QueryString = "select * from BagOfBaguettes where X<=4"
+                PrepareData("BagOfBaguettes");
+
+                var actual = await connection.Query<Full>(new GqlQuery
+                {
+                    AllowLiterals = true,
+                    QueryString = "select * from BagOfBaguettes where X<=4"
+                });
+
+                Assert.Equal(3, actual.Count);
+                Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
+                Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
+                Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
             });
-            
-            Assert.Equal(3, actual.Count);
-            Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
-            Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
-            Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
         }
 
         [Fact]
         public async void Query_projection()
         {
-            PrepareData("Full");
-            
-            var actual = await connection.Query<FullLight>(new Query
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Filter = Filter.LessThanOrEqual("X", new Value {IntegerValue = 4}),
-                Projection = { "__key__", "String" }
-            }, "Full");
-            
-            Assert.Equal(3, actual.Count);
-            Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
-            Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
-            Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
+                PrepareData("Full");
+
+                var actual = await connection.Query<FullLight>(new Query
+                {
+                    Filter = Filter.LessThanOrEqual("X", new Value {IntegerValue = 4}),
+                    Projection = {"__key__", "String"}
+                }, "Full");
+
+                Assert.Equal(3, actual.Count);
+                Assert.Contains(actual, x => x.Id == 1 && x.String == "one");
+                Assert.Contains(actual, x => x.Id == 2 && x.String == "two");
+                Assert.Contains(actual, x => x.Id == 5 && x.String == "five");
+            });
         }
 
         #region POCOs

--- a/src/google-cloud/test-functional/Datastore/DatastoreConnection/UpdateTests.cs
+++ b/src/google-cloud/test-functional/Datastore/DatastoreConnection/UpdateTests.cs
@@ -7,51 +7,57 @@ namespace functionaltests.Datastore.DatastoreConnection
         [Fact]
         public async void Update_without_kind()
         {
-            EnsureEmptyKind("TheUpdater");
-            
-            var poco = new TheUpdater
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = 666,
-                String = "Miav",
-                X = 333
-            };
+                EnsureEmptyKind("TheUpdater");
 
-            await connection.InsertAsync(poco);
+                var poco = new TheUpdater
+                {
+                    Id = 666,
+                    String = "Miav",
+                    X = 333
+                };
 
-            poco.X = 999;
-            await connection.UpdateAsync(poco);
+                await connection.InsertAsync(poco);
 
-            var firstAll = GetAll("TheUpdater");
-            
-            Assert.Equal(1, firstAll.Count);
-            Assert.Equal(666, firstAll[0].Key.Path[0].Id);
-            Assert.Equal("Miav", firstAll[0]["String"].StringValue);
-            Assert.Equal(999, firstAll[0]["X"].IntegerValue);
+                poco.X = 999;
+                await connection.UpdateAsync(poco);
+
+                var firstAll = GetAll("TheUpdater");
+
+                Assert.Equal(1, firstAll.Count);
+                Assert.Equal(666, firstAll[0].Key.Path[0].Id);
+                Assert.Equal("Miav", firstAll[0]["String"].StringValue);
+                Assert.Equal(999, firstAll[0]["X"].IntegerValue);
+            });
         }
         
         [Fact]
         public async void Update_with_kind()
         {
-            EnsureEmptyKind("DeviledPigs");
-            
-            var poco = new TheUpdater
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = 666,
-                String = "Oink",
-                X = 333
-            };
+                EnsureEmptyKind("DeviledPigs");
 
-            await connection.InsertAsync(poco, "DeviledPigs");
+                var poco = new TheUpdater
+                {
+                    Id = 666,
+                    String = "Oink",
+                    X = 333
+                };
 
-            poco.X = 999;
-            await connection.UpdateAsync(poco, "DeviledPigs");
-            
-            var firstAll = GetAll("DeviledPigs");
-            
-            Assert.Equal(1, firstAll.Count);
-            Assert.Equal(666, firstAll[0].Key.Path[0].Id);
-            Assert.Equal("Oink", firstAll[0]["String"].StringValue);
-            Assert.Equal(999, firstAll[0]["X"].IntegerValue);
+                await connection.InsertAsync(poco, "DeviledPigs");
+
+                poco.X = 999;
+                await connection.UpdateAsync(poco, "DeviledPigs");
+
+                var firstAll = GetAll("DeviledPigs");
+
+                Assert.Equal(1, firstAll.Count);
+                Assert.Equal(666, firstAll[0].Key.Path[0].Id);
+                Assert.Equal("Oink", firstAll[0]["String"].StringValue);
+                Assert.Equal(999, firstAll[0]["X"].IntegerValue);
+            });
         }
         
         #region POCOs

--- a/src/google-cloud/test-functional/Datastore/DatastoreConnection/UpsertTests.cs
+++ b/src/google-cloud/test-functional/Datastore/DatastoreConnection/UpsertTests.cs
@@ -7,65 +7,71 @@ namespace functionaltests.Datastore.DatastoreConnection
         [Fact]
         public async void Upsert_without_kind()
         {
-            EnsureEmptyKind("TheUpserter");
-            
-            var poco = new TheUpserter
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = 666,
-                String = "Miav",
-                X = 333
-            };
+                EnsureEmptyKind("TheUpserter");
 
-            await connection.UpsertAsync(poco);
+                var poco = new TheUpserter
+                {
+                    Id = 666,
+                    String = "Miav",
+                    X = 333
+                };
 
-            var firstAll = GetAll("TheUpserter");
-            
-            Assert.Equal(1, firstAll.Count);
-            Assert.Equal(666, firstAll[0].Key.Path[0].Id);
-            Assert.Equal("Miav", firstAll[0]["String"].StringValue);
-            Assert.Equal(333, firstAll[0]["X"].IntegerValue);
+                await connection.UpsertAsync(poco);
 
-            poco.X = 999;
-            await connection.UpsertAsync(poco);
-            
-            var secondAll = GetAll("TheUpserter");
-            
-            Assert.Equal(1, secondAll.Count);
-            Assert.Equal(666, secondAll[0].Key.Path[0].Id);
-            Assert.Equal("Miav", secondAll[0]["String"].StringValue);
-            Assert.Equal(999, secondAll[0]["X"].IntegerValue);
+                var firstAll = GetAll("TheUpserter");
+
+                Assert.Equal(1, firstAll.Count);
+                Assert.Equal(666, firstAll[0].Key.Path[0].Id);
+                Assert.Equal("Miav", firstAll[0]["String"].StringValue);
+                Assert.Equal(333, firstAll[0]["X"].IntegerValue);
+
+                poco.X = 999;
+                await connection.UpsertAsync(poco);
+
+                var secondAll = GetAll("TheUpserter");
+
+                Assert.Equal(1, secondAll.Count);
+                Assert.Equal(666, secondAll[0].Key.Path[0].Id);
+                Assert.Equal("Miav", secondAll[0]["String"].StringValue);
+                Assert.Equal(999, secondAll[0]["X"].IntegerValue);
+            });
         }
         
         [Fact]
         public async void Upsert_with_kind()
         {
-            EnsureEmptyKind("KittensAreEvil");
-            
-            var poco = new TheUpserter
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
             {
-                Id = 666,
-                String = "Miav",
-                X = 333
-            };
+                EnsureEmptyKind("KittensAreEvil");
 
-            await connection.UpsertAsync(poco, "KittensAreEvil");
+                var poco = new TheUpserter
+                {
+                    Id = 666,
+                    String = "Miav",
+                    X = 333
+                };
 
-            var firstAll = GetAll("KittensAreEvil");
-            
-            Assert.Equal(1, firstAll.Count);
-            Assert.Equal(666, firstAll[0].Key.Path[0].Id);
-            Assert.Equal("Miav", firstAll[0]["String"].StringValue);
-            Assert.Equal(333, firstAll[0]["X"].IntegerValue);
+                await connection.UpsertAsync(poco, "KittensAreEvil");
 
-            poco.X = 999;
-            await connection.UpsertAsync(poco, "KittensAreEvil");
-            
-            var secondAll = GetAll("KittensAreEvil");
-            
-            Assert.Equal(1, secondAll.Count);
-            Assert.Equal(666, secondAll[0].Key.Path[0].Id);
-            Assert.Equal("Miav", secondAll[0]["String"].StringValue);
-            Assert.Equal(999, secondAll[0]["X"].IntegerValue);
+                var firstAll = GetAll("KittensAreEvil");
+
+                Assert.Equal(1, firstAll.Count);
+                Assert.Equal(666, firstAll[0].Key.Path[0].Id);
+                Assert.Equal("Miav", firstAll[0]["String"].StringValue);
+                Assert.Equal(333, firstAll[0]["X"].IntegerValue);
+
+                poco.X = 999;
+                await connection.UpsertAsync(poco, "KittensAreEvil");
+
+                var secondAll = GetAll("KittensAreEvil");
+
+                Assert.Equal(1, secondAll.Count);
+                Assert.Equal(666, secondAll[0].Key.Path[0].Id);
+                Assert.Equal("Miav", secondAll[0]["String"].StringValue);
+                Assert.Equal(999, secondAll[0]["X"].IntegerValue);
+            });
         }
         
         #region POCOs


### PR DESCRIPTION
This adds `DatastoreConnectedTestBase.WorkAroundDatastoreEmulatorIssueAsync` and uses it in all of our own datastore functional tests.

Closes #81 