### PR TITLE
Resolve 80: DatastoreConnection.GetByIdOrDefaultAsync throws NullReference if entity does not exist

### DIFF
--- a/src/google-cloud/main/Datastore/DatastoreConnection.cs
+++ b/src/google-cloud/main/Datastore/DatastoreConnection.cs
@@ -173,7 +173,12 @@ namespace RapidCore.GoogleCloud.Datastore
         {
             var entity = await datastoreDb.LookupAsync(key);
 
-            return orm.EntityToPoco<TPoco>(entity);
+            if (entity != null)
+            {
+                return orm.EntityToPoco<TPoco>(entity);
+            }
+
+            return default(TPoco);
         }
         #endregion
 

--- a/src/google-cloud/test-functional/Datastore/DatastoreConnection/InsertAndLoadTests.cs
+++ b/src/google-cloud/test-functional/Datastore/DatastoreConnection/InsertAndLoadTests.cs
@@ -90,6 +90,19 @@ namespace functionaltests.Datastore.DatastoreConnection
         }
         
         [Fact]
+        public async void GetByIdAsync_long_returns_null_onNoMatch()
+        {
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
+            {
+                EnsureEmptyKind("NumericIdPoco");
+
+                var actual = await connection.GetByIdOrDefaultAsync<NumericIdPoco>(1234);
+
+                Assert.Null(actual);
+            });
+        }
+        
+        [Fact]
         public async void GetByIdAsync_string()
         {
             await WorkAroundDatastoreEmulatorIssueAsync(async () =>
@@ -130,6 +143,19 @@ namespace functionaltests.Datastore.DatastoreConnection
 
                 Assert.Equal(poco.Id, actual.Id);
                 Assert.Equal(poco.String, actual.String);
+            });
+        }
+        
+        [Fact]
+        public async void GetByIdAsync_string_returns_null_onNoMatch()
+        {
+            await WorkAroundDatastoreEmulatorIssueAsync(async () =>
+            {
+                EnsureEmptyKind("StringIdPoco");
+
+                var actual = await connection.GetByIdOrDefaultAsync<StringIdPoco>("halleluja-vacation-is-coming-up");
+
+                Assert.Null(actual);
             });
         }
         #endregion


### PR DESCRIPTION
Turns out that I had forgotten to handle the case where no Entity is returned, so let us add it :)

Closes #80 