### PR TITLE
Resolve 85: DatastoreOrm.GetValueName does not work with DateTime

### DIFF
--- a/src/google-cloud/main/Datastore/DatastoreOrm.cs
+++ b/src/google-cloud/main/Datastore/DatastoreOrm.cs
@@ -120,11 +120,22 @@ namespace RapidCore.GoogleCloud.Datastore
         /// Get the name of the Datastore entity value for a given property
         /// </summary>
         /// <param name="propertySelectionExpression"></param>
-        /// <typeparam name="T">The type you are selecting from</typeparam>
+        /// <typeparam name="TEntity">The type you are selecting from</typeparam>
         /// <exception cref="ArgumentException">Thrown if the expression does not point to a property on the given type</exception>
-        public virtual string GetValueName<T>(Expression<Func<T, object>> propertySelectionExpression)
+        public virtual string GetValueName<TEntity>(Expression<Func<TEntity, object>> propertySelectionExpression)
         {
-            var expr = propertySelectionExpression.Body as MemberExpression;
+            MemberExpression expr = null;
+            
+            if (propertySelectionExpression.Body is UnaryExpression)
+            {
+                var unary = propertySelectionExpression.Body as UnaryExpression;
+                expr = unary.Operand as MemberExpression;
+            }
+            else
+            {
+                expr = propertySelectionExpression.Body as MemberExpression;
+            }
+            
 
             if (expr == null)
             {

--- a/src/google-cloud/test-unit/Datastore/DatastoreOrmTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreOrmTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FakeItEasy;
 using Google.Cloud.Datastore.V1;
 using RapidCore.GoogleCloud.Datastore;
@@ -92,6 +93,38 @@ namespace unittests.Datastore
             Assert.StartsWith("The given expression does not point to a member", actual.Message);
         }
 
+        [Fact]
+        public void GetValueName_works_with_DateTime()
+        {
+            var actual = orm.GetValueName<ValueNameVictim>(x => x.MyDateTime);
+            
+            Assert.Equal("MyDateTime", actual);
+        }
+        
+        [Fact]
+        public void GetValueName_works_with_Enum()
+        {
+            var actual = orm.GetValueName<ValueNameVictim>(x => x.MyEnum);
+            
+            Assert.Equal("MyEnum", actual);
+        }
+        
+        [Fact]
+        public void GetValueName_works_with_List()
+        {
+            var actual = orm.GetValueName<ValueNameVictim>(x => x.MyList);
+            
+            Assert.Equal("MyList", actual);
+        }
+        
+        [Fact]
+        public void GetValueName_works_with_int()
+        {
+            var actual = orm.GetValueName<ValueNameVictim>(x => x.MyInt);
+            
+            Assert.Equal("MyInt", actual);
+        }
+
         #region POCOs
         public class Bee {}
         
@@ -102,11 +135,25 @@ namespace unittests.Datastore
             public string MyProperty { get; set; }
             
             public Deeper TheDeeper { get; set; }
+            
+            public DateTime MyDateTime { get; set; }
+            
+            public Greeting MyEnum { get; set; }
+            
+            public List<string> MyList { get; set; }
+            
+            public int MyInt { get; set; }
         }
         
         public class Deeper
         {
             public int DangerIs => 23;
+        }
+        
+        public enum Greeting
+        {
+            Hello = 0,
+            Hi
         }
         #endregion
     }

--- a/src/google-cloud/test-unit/Datastore/DatastoreOrmTests.cs
+++ b/src/google-cloud/test-unit/Datastore/DatastoreOrmTests.cs
@@ -87,10 +87,8 @@ namespace unittests.Datastore
         [Fact]
         public void GetValueName_1_level_only()
         {
-            var actual = Record.Exception(() => orm.GetValueName<ValueNameVictim>(x => x.TheDeeper.DangerIs));
-
-            Assert.IsType<ArgumentException>(actual);
-            Assert.StartsWith("The given expression does not point to a member", actual.Message);
+            var actual = orm.GetValueName<ValueNameVictim>(x => x.TheDeeper.DangerIs);
+            Assert.Equal("DangerIs", actual);
         }
 
         [Fact]


### PR DESCRIPTION
Adds tests that show the problem and a possible fix.

The problem turns out to be that the expression ends up being `Convert(x.MyProperty)` rather than the expected `x.MyProperty`.

Closes #85 