### PR TITLE
Publish preview docs when merging to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,26 @@ before_install:
 script:
   - chmod +x ./Build.sh && ./Build.sh --quiet verify
 deploy:
-  provider: gcs
-  access_key_id: GOOG3WOQ425K2J262RM3
-  secret_access_key:
-    secure: AKGMdkOY4dPwPAZQGPmHULiMidMcdacQYKHPyqANsqnooKEpcdL3AwXRsv9YIbz4x/bkDdHsh95oGoePZn9kNbilb8HC9NgwfA7/+7o/yROSMpX3DPu3wD5Ipc7UOULlU4Nhj7QMHdEuizTTnig7Kgwc+Zfgo5V7/KN8kYcglittIdw0aSr1VKWpKBowMd2OpukQCFEtWz+ca3/G3hNic1v4DGCyUmMoFW0S1nrueoteTbgqUx/WBSpwhzNHCWPt0WjoaSNOak8EjDFcLNqtbPZ63eC/Uo2OTLRIIJKdmt26TuGPHq7oj8izeKsDbc1D6vWYpvu8BJ/EQC5c4F1H9gQIfLgoYASHqIxuLlzY2OQ7Gm8K7mwj+pCkn27KSmlPu1HANTPI0KtJVqnCHq2qN1jBWw1WZs9k/0KQfoJkd/xnofDjCs/CF9iiPtePqOjX40C5LFgg/Wuxwz2AIeALM/Lcj187hrKIHNQdYLxnABJT3TwW0T5bevWUol+ZoXxs7RceLGabJCuAUHVNyyr7WCpVxqJLFLOin0hDCx0xtsv3T+KRD2OjAE3y/5qHRPdmp16l6iZh6yYN0GNiacXmU2RQR+YjNp/x61P4g0kSNS44QhQYukbXMlTzl3eM8l3VQxteplKzP4ljlw6Xx1YHWTZRpd3q6/k67UeChH/BgBc=
-  bucket: docs.rapidcore.io
-  local-dir: docs-generated
-  skip_cleanup: true
-  acl: public-read
-  on:
-    repo: rapidcore/rapidcore
-    tags: true
+  - provider: gcs
+    access_key_id: GOOG3WOQ425K2J262RM3
+    secret_access_key:
+      secure: AKGMdkOY4dPwPAZQGPmHULiMidMcdacQYKHPyqANsqnooKEpcdL3AwXRsv9YIbz4x/bkDdHsh95oGoePZn9kNbilb8HC9NgwfA7/+7o/yROSMpX3DPu3wD5Ipc7UOULlU4Nhj7QMHdEuizTTnig7Kgwc+Zfgo5V7/KN8kYcglittIdw0aSr1VKWpKBowMd2OpukQCFEtWz+ca3/G3hNic1v4DGCyUmMoFW0S1nrueoteTbgqUx/WBSpwhzNHCWPt0WjoaSNOak8EjDFcLNqtbPZ63eC/Uo2OTLRIIJKdmt26TuGPHq7oj8izeKsDbc1D6vWYpvu8BJ/EQC5c4F1H9gQIfLgoYASHqIxuLlzY2OQ7Gm8K7mwj+pCkn27KSmlPu1HANTPI0KtJVqnCHq2qN1jBWw1WZs9k/0KQfoJkd/xnofDjCs/CF9iiPtePqOjX40C5LFgg/Wuxwz2AIeALM/Lcj187hrKIHNQdYLxnABJT3TwW0T5bevWUol+ZoXxs7RceLGabJCuAUHVNyyr7WCpVxqJLFLOin0hDCx0xtsv3T+KRD2OjAE3y/5qHRPdmp16l6iZh6yYN0GNiacXmU2RQR+YjNp/x61P4g0kSNS44QhQYukbXMlTzl3eM8l3VQxteplKzP4ljlw6Xx1YHWTZRpd3q6/k67UeChH/BgBc=
+    bucket: docs.rapidcore.io
+    local-dir: docs-generated
+    skip_cleanup: true
+    acl: public-read
+    on:
+      repo: rapidcore/rapidcore
+      tags: true
+  - provider: gcs
+    access_key_id: GOOG3WOQ425K2J262RM3
+    secret_access_key:
+      secure: AKGMdkOY4dPwPAZQGPmHULiMidMcdacQYKHPyqANsqnooKEpcdL3AwXRsv9YIbz4x/bkDdHsh95oGoePZn9kNbilb8HC9NgwfA7/+7o/yROSMpX3DPu3wD5Ipc7UOULlU4Nhj7QMHdEuizTTnig7Kgwc+Zfgo5V7/KN8kYcglittIdw0aSr1VKWpKBowMd2OpukQCFEtWz+ca3/G3hNic1v4DGCyUmMoFW0S1nrueoteTbgqUx/WBSpwhzNHCWPt0WjoaSNOak8EjDFcLNqtbPZ63eC/Uo2OTLRIIJKdmt26TuGPHq7oj8izeKsDbc1D6vWYpvu8BJ/EQC5c4F1H9gQIfLgoYASHqIxuLlzY2OQ7Gm8K7mwj+pCkn27KSmlPu1HANTPI0KtJVqnCHq2qN1jBWw1WZs9k/0KQfoJkd/xnofDjCs/CF9iiPtePqOjX40C5LFgg/Wuxwz2AIeALM/Lcj187hrKIHNQdYLxnABJT3TwW0T5bevWUol+ZoXxs7RceLGabJCuAUHVNyyr7WCpVxqJLFLOin0hDCx0xtsv3T+KRD2OjAE3y/5qHRPdmp16l6iZh6yYN0GNiacXmU2RQR+YjNp/x61P4g0kSNS44QhQYukbXMlTzl3eM8l3VQxteplKzP4ljlw6Xx1YHWTZRpd3q6/k67UeChH/BgBc=
+    bucket: preview-docs.rapidcore.io
+    local-dir: docs-generated
+    skip_cleanup: true
+    acl: public-read
+    on:
+      repo: rapidcore/rapidcore
+      tags: false
+      branch: master

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library with classes for the stuff you would otherwise build in every single pro
 
 We target `NetStandard1.6` to include as many .NET runtimes as possible, while still having access to as many features as possible (see [Microsoft's version matrix](https://github.com/dotnet/standard/blob/master/docs/versions.md)).
 
-Go to [documentation](http://docs.rapidcore.io/)
+Go to [documentation](http://docs.rapidcore.io/) - preview features are available on the [preview docs site](http://preview-docs.rapidcore.io/)
 
 ## Versioning
 


### PR DESCRIPTION
Documentation is built and published to preview-docs.rapidcore.io when building on master.

Closes #84 