### PR TITLE
Resolve 94: Iso3166Countries should have a method for validating a country code

### DIFF
--- a/docs/RapidCore.Globalization/ISO3166_Countries.md
+++ b/docs/RapidCore.Globalization/ISO3166_Countries.md
@@ -81,3 +81,57 @@ public class SomeProcessor()
     }
 }
 ```
+
+## Validating a given country code
+
+If you need to validate whether a given country code is valid or not you have 2 options depending on what else you need.
+
+1. Use `IsValidCountryCode(string)` if you do not need the country instance, but just needs to know whether the code is valid
+2. Use `Get(string)` and check for null, if you need the country instance
+
+```csharp
+using RapidCore.Globalization;
+
+public class SomeHandler()
+{
+    private readonly Iso3166Countries countries;
+
+    public SomeHandler(Iso3166Countries countries)
+    {
+        this.countries = countries;
+    }
+
+    public void Myes(SomeThing input)
+    {
+        /**
+         * OPTION 1
+         *
+         * If you just need to know whether a given country code
+         * is valid, but you do not need the actual country instance
+         * you can use the "IsValidCountryCode" convenience method.
+         */
+        if (!countries.IsValidCountryCode(input.CountryCode))
+        {
+            throw new ArgumentException($"{input.CountryCode} is not a valid ISO 3166 country code");
+        }
+
+        /**
+         * OPTION 2
+         *
+         * If on the other hand, you actually need information about
+         * the country, you might as well just use "Get" and check for null
+         */
+        var country = countries.Get(input.CountryCode);
+
+        if (country == default(Iso3166Country))
+        {
+            throw new ArgumentException($"{input.CountryCode} is not a valid ISO 3166 country code");
+        }
+
+        var someOtherThing = new OtherThing
+        {
+            CountryCode = country.CodeNumeric
+        };
+    }
+}
+```

--- a/docs/RapidCore.Globalization/ISO4217_Currencies.md
+++ b/docs/RapidCore.Globalization/ISO4217_Currencies.md
@@ -81,3 +81,57 @@ public class SomeProcessor()
     }
 }
 ```
+
+## Validating a given currency code
+
+If you need to validate whether a given currency code is valid or not you have 2 options depending on what else you need.
+
+1. Use `IsValidCurrencyCode(string)` if you do not need the currency instance, but just needs to know whether the code is valid
+2. Use `Get(string)` and check for null, if you need the currency instance
+
+```csharp
+using RapidCore.Globalization;
+
+public class SomeHandler()
+{
+    private readonly Iso4217Currencies currencies;
+
+    public SomeHandler(Iso4217Currencies currencies)
+    {
+        this.currencies = currencies;
+    }
+
+    public void Myes(SomeThing input)
+    {
+        /**
+         * OPTION 1
+         *
+         * If you just need to know whether a given currency code
+         * is valid, but you do not need the actual currency instance
+         * you can use the "IsValidCurrencyCode" convenience method.
+         */
+        if (!currencies.IsValidCurrencyCode(input.CurrencyCode))
+        {
+            throw new ArgumentException($"{input.CurrencyCode} is not a valid ISO 4217 currency code");
+        }
+
+        /**
+         * OPTION 2
+         *
+         * If on the other hand, you actually need information about
+         * the currency, you might as well just use "Get" and check for null
+         */
+        var currency = currencies.Get(input.CurrencyCode);
+
+        if (currency == default(Iso4217Currency))
+        {
+            throw new ArgumentException($"{input.CurrencyCode} is not a valid ISO 4217 currency code");
+        }
+
+        var someOtherThing = new OtherThing
+        {
+            CurrencyCode = currency.CodeNumeric
+        };
+    }
+}
+```

--- a/src/core/main/Globalization/Iso3166Countries.cs
+++ b/src/core/main/Globalization/Iso3166Countries.cs
@@ -269,6 +269,11 @@ namespace RapidCore.Globalization
         /// <returns>The matching country or null</returns>
         public virtual CountryIso3166 Get(string alpha2OrAlpha3OrNumeric)
         {
+            if (string.IsNullOrWhiteSpace(alpha2OrAlpha3OrNumeric))
+            {
+                return null;
+            }
+            
             // the input could be numeric, but sent in as a string
             if (int.TryParse(alpha2OrAlpha3OrNumeric, out int numeric))
             {
@@ -318,6 +323,16 @@ namespace RapidCore.Globalization
             }
 
             return a.Is(bAlpha2OrAlpha3OrNumeric);
+        }
+
+        /// <summary>
+        /// Check whether a given country code is valid
+        /// </summary>
+        /// <param name="alpha2OrAlpha3OrNumeric">Country code in either alpha-2, alpha-3 or numeric</param>
+        /// <returns><c>True</c> if the code is valid, <c>false</c> otherwise</returns>
+        public virtual bool IsValidCountryCode(string alpha2OrAlpha3OrNumeric)
+        {
+            return Get(alpha2OrAlpha3OrNumeric) != default(CountryIso3166);
         }
     }
 }

--- a/src/core/main/Globalization/Iso4217Currencies.cs
+++ b/src/core/main/Globalization/Iso4217Currencies.cs
@@ -200,6 +200,11 @@ namespace RapidCore.Globalization
         /// <returns>The matching currency or <c>null</c></returns>
         public virtual CurrencyIso4217 Get(string alphaOrNumeric)
         {
+            if (string.IsNullOrWhiteSpace(alphaOrNumeric))
+            {
+                return null;
+            }
+            
             // the input could be numeric, but sent in as a string
             if (int.TryParse(alphaOrNumeric, out int numeric))
             {
@@ -236,6 +241,16 @@ namespace RapidCore.Globalization
             }
 
             return a.Is(bAlphaOrNumeric);
+        }
+        
+        /// <summary>
+        /// Check whether a given currency code is valid
+        /// </summary>
+        /// <param name="alphaOrNumeric">Alphabetic or numeric currency code</param>
+        /// <returns><c>True</c> if the code is valid, <c>false</c> otherwise</returns>
+        public virtual bool IsValidCurrencyCode(string alphaOrNumeric)
+        {
+            return Get(alphaOrNumeric) != default(CurrencyIso4217);
         }
     }
 }

--- a/src/core/test-unit/Globalization/Iso3166CountriesTests.cs
+++ b/src/core/test-unit/Globalization/Iso3166CountriesTests.cs
@@ -11,6 +11,17 @@ namespace RapidCore.UnitTests.Globalization
         {
             countries = new Iso3166Countries();
         }
+        
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("TotallyNotACountryCode")]
+        [InlineData("_208")] // does not register as "numeric", so ends up with null
+        public void Get_returnsNull_ifGiven(string given)
+        {
+            Assert.Null(countries.Get(given));
+        }
 
         [Fact]
         public void Get_alpha2()
@@ -65,6 +76,24 @@ namespace RapidCore.UnitTests.Globalization
         public void Matches(string theOneToCheck, string theOneItShouldBe, bool expected)
         {
             Assert.Equal(expected, countries.Matches(theOneToCheck, theOneItShouldBe));
+        }
+        
+        [Theory]
+        // invalid
+        [InlineData("alala", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        [InlineData("   ", false)]
+        // valid
+        [InlineData("dk", true)]
+        [InlineData("dK", true)]
+        [InlineData("DK", true)]
+        [InlineData("dnk", true)]
+        [InlineData("dNK", true)]
+        [InlineData("208", true)]
+        public void IsValidCountryCode(string countryCodeToCheck, bool expected)
+        {
+            Assert.Equal(expected, countries.IsValidCountryCode(countryCodeToCheck));
         }
     }
 }

--- a/src/core/test-unit/Globalization/Iso4217CurrenciesTests.cs
+++ b/src/core/test-unit/Globalization/Iso4217CurrenciesTests.cs
@@ -44,6 +44,17 @@ namespace RapidCore.UnitTests.Globalization
                 }
             }
         }
+        
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("TotallyNotACurrencyCode")]
+        [InlineData("_208")] // does not register as "numeric", so ends up with null
+        public void Get_returnsNull_ifGiven(string given)
+        {
+            Assert.Null(currencies.Get(given));
+        }
 
         [Fact]
         public void Get_alpha()
@@ -99,6 +110,21 @@ namespace RapidCore.UnitTests.Globalization
         public void Matches(string theOneToCheck, string theOneItShouldBe, bool expected)
         {
             Assert.Equal(expected, currencies.Matches(theOneToCheck, theOneItShouldBe));
+        }
+        
+        [Theory]
+        // invalid
+        [InlineData("alala", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        [InlineData("   ", false)]
+        // valid
+        [InlineData("dkk", true)]
+        [InlineData("dKK", true)]
+        [InlineData("208", true)]
+        public void IsValidCurrencyCode(string currencyCodeToCheck, bool expected)
+        {
+            Assert.Equal(expected, currencies.IsValidCurrencyCode(currencyCodeToCheck));
         }
     }
 }


### PR DESCRIPTION
This adds `bool IsValid**Code(string)` to the country and currency code classes. The issue only mentions adding it for countries, but these two classes are so similar that I thought it best to add it to the currency class as well.

During testing I also noticed that we did not have any tests checking how the `Get(string)` methods handled null, empty strings, invalid codes etc. so I also added those - and fixed a bug when they were given null.

TL;DR; New methods:
- `bool Iso3166Countries.IsValidCountryCode(string)`
- `bool Iso4217Currencies.IsValidCurrencyCode(string)`

Closes #94 