### PR TITLE
Resolve 91: Docs: links in Datastore/Introduction do not work

### DIFF
--- a/docs/Datastore/Connection.md
+++ b/docs/Datastore/Connection.md
@@ -1,6 +1,6 @@
 # High-level Datastore connection
 
-`RapidCore.GoogleCloud.Datastore.DatastoreConnection` is a high-level connection class providing basic methods for working with Entities using the [the ORM](./Orm).
+`RapidCore.GoogleCloud.Datastore.DatastoreConnection` is a high-level connection class providing basic methods for working with Entities using the [the ORM](../Orm).
 
 It is not meant to cover every single use-case directly. For the more exotic use-cases, it provides direct access to the low-level connection from Google's SDK.
 

--- a/docs/Datastore/Introduction.md
+++ b/docs/Datastore/Introduction.md
@@ -4,5 +4,5 @@
 
 RapidCore has the following tools for working with it:
 
-- An [ORM](https://en.wikipedia.org/wiki/Object-relational_mapping) ([see docs](./Orm))
-- High-level connection class using the ORM ([see docs](./Connection))
+- An [ORM](https://en.wikipedia.org/wiki/Object-relational_mapping) ([see docs](../Orm))
+- High-level connection class using the ORM ([see docs](../Connection))


### PR DESCRIPTION
Fixes a few broken links in the Datastore documentation.

Closes #91 