### PR TITLE
Resolve 89:  Update mkdocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: RapidCore Docs
 theme: readthedocs
 repo_url: https://github.com/rapidcore/rapidcore/
-pages:
+nav:
   - RapidCore: index.md
   - Audit:
       - Introduction: Audit/Introduction.md


### PR DESCRIPTION
Apparently the `pages` structure in the `mkdocs` config has been renamed to `nav`, so this PR fixes that.

Closes #89 