### PR TITLE
We should extract and reuse the "Type conversion" stuff in EnvironmentVariables and ConfigBase

### DIFF
--- a/src/core/main/Configuration/ConfigBase.cs
+++ b/src/core/main/Configuration/ConfigBase.cs
@@ -23,30 +23,21 @@ namespace RapidCore.Configuration
 
         protected T Get<T>(string key, T defaultValue)
         {
-            string value = configuration[key];
+            var value = configuration[key];
 
             if (string.IsNullOrEmpty(value))
             {
                 return defaultValue;
             }
 
-            if (typeof(T).GetTypeInfo().IsEnum)
-            {
-                // try..catch is not as pretty as Enum.TryParse, but
-                // TryParse requires T to be non-nullable, which is
-                // not a constraint for us
-                try
-                {
-                    return (T)Enum.Parse(typeof(T), value, true);
-                }
-                catch (Exception)
-                {
-                    return defaultValue;
-                }
-            }
+            var converted = TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
 
-            return (T)Convert.ChangeType(value, typeof(T));
+            if (converted == null)
+            {
+                return defaultValue;
+            }
+            
+            return (T) converted;
         }
     }
 }
-#endif

--- a/src/core/main/Configuration/ConfigBase.cs
+++ b/src/core/main/Configuration/ConfigBase.cs
@@ -30,14 +30,11 @@ namespace RapidCore.Configuration
                 return defaultValue;
             }
 
-            var converted = TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
-
-            if (converted == null)
+            if (TypeDescriptor.GetConverter(typeof(T)).IsValid(value))
             {
-                return defaultValue;
+                return (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
             }
-            
-            return (T) converted;
+            return defaultValue;
         }
     }
 }

--- a/src/core/main/Configuration/ConfigBase.cs
+++ b/src/core/main/Configuration/ConfigBase.cs
@@ -1,5 +1,6 @@
 #if NETSTANDARD2_0
 using System;
+using System.ComponentModel;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 
@@ -38,3 +39,4 @@ namespace RapidCore.Configuration
         }
     }
 }
+#endif

--- a/src/core/main/Environment/EnvironmentVariables.cs
+++ b/src/core/main/Environment/EnvironmentVariables.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace RapidCore.Environment
 {
@@ -27,7 +27,14 @@ namespace RapidCore.Environment
                 return defaultValue;
             }
 
-            return (T)Convert.ChangeType(value, typeof(T));
+            var converted = TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
+
+            if (converted == null)
+            {
+                return defaultValue;
+            }
+            
+            return (T) converted;
         }
 
         /// <summary>

--- a/src/core/main/Environment/EnvironmentVariables.cs
+++ b/src/core/main/Environment/EnvironmentVariables.cs
@@ -27,14 +27,11 @@ namespace RapidCore.Environment
                 return defaultValue;
             }
 
-            var converted = TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
-
-            if (converted == null)
+            if (TypeDescriptor.GetConverter(typeof(T)).IsValid(value))
             {
-                return defaultValue;
+                return (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
             }
-            
-            return (T) converted;
+            return defaultValue;
         }
 
         /// <summary>

--- a/src/core/main/rapidcore.csproj
+++ b/src/core/main/rapidcore.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="SSH.NET" Version="2016.0.0" />
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.7.0" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>

--- a/src/core/test-unit/Configuration/ConfigBaseTests.cs
+++ b/src/core/test-unit/Configuration/ConfigBaseTests.cs
@@ -1,6 +1,7 @@
 #if NETSTANDARD2_0
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
+using RapidCore.Configuration;
 using Xunit;
 
 namespace RapidCore.UnitTests.Configuration
@@ -172,3 +173,4 @@ namespace RapidCore.UnitTests.Configuration
         #endregion
     }
 }
+#endif

--- a/src/core/test-unit/Configuration/ConfigBaseTests.cs
+++ b/src/core/test-unit/Configuration/ConfigBaseTests.cs
@@ -1,7 +1,6 @@
 #if NETSTANDARD2_0
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
-using RapidCore.Configuration;
 using Xunit;
 
 namespace RapidCore.UnitTests.Configuration
@@ -173,4 +172,3 @@ namespace RapidCore.UnitTests.Configuration
         #endregion
     }
 }
-#endif


### PR DESCRIPTION
For type conversion, `TypeConverter` is being used instead of `Convert.ChangeType`. This also works for enums, which therefore reduces the amount of code and therefore also the amount of code duplication. A new class has therefore not been made.