### PR TITLE
WIP: Resolve 124 - Mongo: it would be nice to be able to ensure indexes for types with non-default collection name

### DIFF
--- a/src/mongo/main/EntityAttribute.cs
+++ b/src/mongo/main/EntityAttribute.cs
@@ -8,5 +8,6 @@ namespace RapidCore.Mongo
     [AttributeUsage(System.AttributeTargets.Class, Inherited = false)]
     public class EntityAttribute : Attribute
     {
+        public string CollectionName { get; set; }
     }
 }

--- a/src/mongo/main/Internal/IndexFromTypeExtensions.cs
+++ b/src/mongo/main/Internal/IndexFromTypeExtensions.cs
@@ -10,7 +10,16 @@ namespace RapidCore.Mongo.Internal
     {
         public static string GetCollectionName(this TypeInfo type)
         {
-            return type.Name;
+            var entityAttributes = type.GetSpecificAttribute<EntityAttribute>();
+
+            string collectionName = null;
+            
+            if (entityAttributes.Count > 0)
+            {
+                collectionName = entityAttributes.FirstOrDefault()?.CollectionName;
+            }
+            
+            return collectionName ?? type.Name;
         }
 
         public static IndexDefinitionCollection GetIndexDefinitions(this TypeInfo type)

--- a/src/mongo/test-functional/MongoManagerTests/EnsureIndexesWithCustomCollectionNameTests.cs
+++ b/src/mongo/test-functional/MongoManagerTests/EnsureIndexesWithCustomCollectionNameTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using RapidCore.Mongo.Internal;
+using Xunit;
+
+namespace RapidCore.Mongo.FunctionalTests.MongoManagerTests
+{
+    public class EnsureIndexesWithCustomCollectionNameTests : MongoManagerTestsBase
+    {
+        [Fact]
+        public void CanCreateSimpleIndexes()
+        {
+            var actual = CreateAndGetIndexes<SimpleIndexes>();
+
+            Assert.Equal(3, actual.Count); // the auto-generated "_id_" and our own
+            Assert.Equal(new BsonDocument().Add("String", 1), actual["string_index"].GetElement("key").Value);
+            Assert.Equal(new BsonDocument().Add("Int", 1), actual["Int_1"].GetElement("key").Value);
+        }
+
+        [Fact]
+        public void DoNothingIfTheIndexAlreadyExists_andIsTheSame()
+        {
+            CreateAndGetIndexes<SimpleIndexes>(); // should drop and create
+            var afterSecondRun = CreateAndGetIndexes<SimpleIndexes>(false); // should _NOT_ drop
+
+            Assert.Equal(3, afterSecondRun.Count); // the auto-generated "_id_" and our own
+            Assert.Equal(new BsonDocument().Add("String", 1), afterSecondRun["string_index"].GetElement("key").Value);
+            Assert.Equal(new BsonDocument().Add("Int", 1), afterSecondRun["Int_1"].GetElement("key").Value);
+        }
+
+        #region Simple indexes
+        [Entity(CollectionName = "Simples")]
+        private class SimpleIndexes
+        {
+            [Index("string_index")]
+            public string String { get; set; }
+
+            [Index]
+            public int Int { get; set; }
+        }
+        #endregion
+    }
+}

--- a/src/mongo/test-unit/Internal/IndexFromTypeExtensionsTests.cs
+++ b/src/mongo/test-unit/Internal/IndexFromTypeExtensionsTests.cs
@@ -8,6 +8,24 @@ namespace RapidCore.Mongo.UnitTests.Internal
 {
     public class IndexFromTypeExtensionsTests
     {
+        #region GetCollectionName
+        [Fact]
+        public void GetCollectionName_default_collectionName_is_theNameOfTheType()
+        {
+            var actual = typeof(EntityWithDefaultCollectionName).GetTypeInfo().GetCollectionName();
+            
+            Assert.Equal("EntityWithDefaultCollectionName", actual);
+        }
+        
+        [Fact]
+        public void GetCollectionName_canTakeName_fromEntityAttribute()
+        {
+            var actual = typeof(EntityWithCollectionName).GetTypeInfo().GetCollectionName();
+            
+            Assert.Equal("DonaldDucks", actual);
+        }
+        #endregion
+        
         [Fact]
         public void DetectsRecursionAndStops()
         {
@@ -47,6 +65,18 @@ namespace RapidCore.Mongo.UnitTests.Internal
 
             [Index]
             public string ThisIsOk { get; set; }
+        }
+        #endregion
+
+        #region Collection name victims
+        [Entity]
+        private class EntityWithDefaultCollectionName
+        {
+        }
+        
+        [Entity(CollectionName = "DonaldDucks")]
+        private class EntityWithCollectionName
+        {
         }
         #endregion
     }


### PR DESCRIPTION
It uses an _optional_ property on `EntityAttribute` where a custom collection name can be defined. If it is not defined, then the pre-existing behaviour of defaulting to `GetType().Name` is used.

Closes #124 