### PR TITLE
Fix redis applock sonarqube comments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,13 @@ services:
     ports:
       - "6379:6379"
 
+  redis-ui:
+    image: rediscommander/redis-commander
+    environment:
+      REDIS_HOSTS: local:redis:6379
+    ports:
+      - 63791:8081
+
   postgresdb:
     image: postgres:10.1-alpine
     environment:

--- a/src/redis/main/Locking/RedisDistributedAppLock.cs
+++ b/src/redis/main/Locking/RedisDistributedAppLock.cs
@@ -171,7 +171,9 @@ namespace RapidCore.Redis.Locking
             if (disposing)
             {
                 // DISPOSE THE UNDERLYING REDIS STUFF
-                // TODO Lock release can return false!!! So deal with that biatch..
+                // see issue: https://github.com/rapidcore/rapidcore/issues/26
+                // for discussion about what to do if we fail while
+                // disposing the lock
                 _redisDb?.LockRelease(Name, LockHandle);
                 Name = default(string);
                 LockHandle = default(string);

--- a/src/redis/main/Locking/RedisDistributedAppLock.cs
+++ b/src/redis/main/Locking/RedisDistributedAppLock.cs
@@ -127,7 +127,6 @@ namespace RapidCore.Redis.Locking
             finally
             {
                 stopWatch?.Stop();
-                stopWatch = null;
             }
         }
 

--- a/src/redis/main/Locking/RedisDistributedAppLock.cs
+++ b/src/redis/main/Locking/RedisDistributedAppLock.cs
@@ -157,7 +157,7 @@ namespace RapidCore.Redis.Locking
         /// </summary>
         public void Dispose()
         {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) below.
             Dispose(true);
             GC.SuppressFinalize(this);
         }
@@ -180,6 +180,11 @@ namespace RapidCore.Redis.Locking
             }
 
             _disposedValue = true;
+        }
+
+        ~RedisDistributedAppLock()
+        {
+            Dispose(false);
         }
     }
 }


### PR DESCRIPTION
Fixes the comments that SonarQube has for the `RedisDistributedAppLock`.

It also adds a functional test that proves that a using block that throws an exception leads to the lock (that we were using) is released.

Also, it adds `redis-commander` to `docker-compose`.