### PR TITLE
Make postgres migration loader load completed steps

### DIFF
--- a/src/postgresql/main/Migration/PostgreSqlMigrationStorage.cs
+++ b/src/postgresql/main/Migration/PostgreSqlMigrationStorage.cs
@@ -3,6 +3,7 @@ using RapidCore.Migration;
 using RapidCore.PostgreSql.Internal;
 using System;
 using System.Data;
+using System.Linq;
 using System.Threading.Tasks;
 using RapidCore.PostgreSql.Migration.Internal;
 
@@ -44,6 +45,19 @@ namespace RapidCore.PostgreSql.Migration
                 new {
                     MigrationName = migrationName
                 });
+
+            if (migrationInfo != null)
+            {
+                var completedStepsFromDb = await db.QueryAsync<string>(
+                    $"select * from {PostgreSqlConstants.CompletedStepsTableName} where migrationinfoid=@MigrationInfoId",
+                    new
+                    {
+                        MigrationInfoId = int.Parse(migrationInfo.Id)
+                    });
+            
+                migrationInfo.StepsCompleted = completedStepsFromDb.ToList();
+            }
+
             return migrationInfo;
         }
 

--- a/src/postgresql/test-functional/Migrations/MigrationTests.cs
+++ b/src/postgresql/test-functional/Migrations/MigrationTests.cs
@@ -82,6 +82,16 @@ namespace RapidCore.PostgreSql.FunctionalTests.Migrations
                 new PostgreSqlMigrationStorage()
             );
 
+            /**
+             * Actually "run" the first step from Migration01,
+             * as this will make the migration fail, if it tries
+             * to rerun the step.
+             */
+            await db.ExecuteAsync(@"
+                    alter table __Counter
+                    add column At timestamp
+                    ;");
+            
             await InsertMigrationInfo(new MigrationInfo
             {
                 Id = "1",


### PR DESCRIPTION
The `PostgreSqlMigrationStorage.GetMigrationInfoAsync` method did not load the list of completed steps, which meant that if a multi-step migration had failed on step 2 and we tried to re-run it, it would _likely_ fail as the first step would likely not be able to be repeated.

Anyway... this MR fixes that :)

We actually had a functional test that was supposed to show this, but it was flawed :( I also fixed that :)

Fixes #149 