### PR TITLE
Turn static strings into consts to avoid security issues

### DIFF
--- a/src/mongo/main/Migration/Internal/MigrationDocument.cs
+++ b/src/mongo/main/Migration/Internal/MigrationDocument.cs
@@ -10,7 +10,8 @@ namespace RapidCore.Mongo.Migration.Internal
     /// </summary>
     public class MigrationDocument
     {
-        [BsonIgnore] public static string CollectionName = "__RapidCoreMigrations";
+        [BsonIgnore]
+        public const string CollectionName = "__RapidCoreMigrations";
 
         [BsonIgnoreIfDefault]
         public ObjectId Id { get; set; }

--- a/src/redis/main/Migration/RedisMigrationStorage.cs
+++ b/src/redis/main/Migration/RedisMigrationStorage.cs
@@ -8,7 +8,7 @@ namespace RapidCore.Redis.Migration
 {
     public class RedisMigrationStorage : IMigrationStorage
     {
-        public static string KeyPrefix = "__rapidcore:migrations:";
+        public const string KeyPrefix = "__rapidcore:migrations:";
         
         private IDatabase GetDatabase(IMigrationContext context)
         {


### PR DESCRIPTION
According to SonarQube, leaving them as "public static" is a
vulnerability, which is correct in some cases. In our case it probably
is not. The only thing we lose by using const, is that references to the
constant are replaced at compile time.