### PR TITLE
Resolve: Be helpful when unable to resolve ValueMasker

### DIFF
--- a/src/core/main/Audit/AuditDiffer.cs
+++ b/src/core/main/Audit/AuditDiffer.cs
@@ -59,12 +59,8 @@ namespace RapidCore.Audit
 
                     if (attr.DoMaskValue)
                     {
-                        if (!attr.ValueMasker.ImplementsInterface(typeof(IAuditValueMasker)))
-                        {
-                            throw new ArgumentException($"A {nameof(AuditAttribute.ValueMasker)} must implement {typeof(IAuditValueMasker).Name}, which {attr.ValueMasker.Name} does not.");
-                        }
-                        
-                        var masker = (IAuditValueMasker)container.Resolve(attr.ValueMasker);
+                        var masker = GetValidValueMaskerOrThrow(attr);
+
                         change.OldValue = masker.MaskValue(change.OldValue);
                         change.NewValue = masker.MaskValue(change.NewValue);
                     }
@@ -86,6 +82,31 @@ namespace RapidCore.Audit
             var attr = member.GetCustomAttribute<AuditAttribute>();
 
             return !attr.Include;
+        }
+
+        private IAuditValueMasker GetValidValueMaskerOrThrow(AuditAttribute attr)
+        {
+            if (!attr.ValueMasker.ImplementsInterface(typeof(IAuditValueMasker)))
+            {
+                throw new ArgumentException($"A {nameof(AuditAttribute.ValueMasker)} must implement {typeof(IAuditValueMasker).Name}, which {attr.ValueMasker.Name} does not.");
+            }
+
+            try
+            {
+                // this cast should be ok, as we have just checked the type above
+                var masker = (IAuditValueMasker)container.Resolve(attr.ValueMasker);
+
+                if (masker == null)
+                {
+                    throw new NullReferenceException("container.Resolve returned null");
+                }
+
+                return masker;
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"The value masker \"{attr.ValueMasker.Name}\" could not be resolved through the container adapter \"{container.GetType().Name}\". Has it been registered in the container?", e);
+            }
         }
     }
 }

--- a/src/core/main/Audit/AuditDiffer.cs
+++ b/src/core/main/Audit/AuditDiffer.cs
@@ -105,7 +105,8 @@ namespace RapidCore.Audit
             }
             catch (Exception e)
             {
-                throw new ArgumentException($"The value masker \"{attr.ValueMasker.Name}\" could not be resolved through the container adapter \"{container.GetType().Name}\". Has it been registered in the container?", e);
+                
+                throw new FailureToResolveException($"The value masker \"{attr.ValueMasker.Name}\" could not be resolved through the container adapter \"{container.GetType().Name}\". Has it been registered in the container?", e);
             }
         }
     }

--- a/src/core/main/FailureToResolveException.cs
+++ b/src/core/main/FailureToResolveException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace RapidCore
+{
+    /// <summary>
+    /// Use when code failed to resolve something from
+    /// a DI container or whatever else makes semantic sense.
+    /// </summary>
+    [Serializable]
+    public class FailureToResolveException : Exception
+    {
+        public FailureToResolveException(string message) : base(message)
+        {
+        }
+
+        public FailureToResolveException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/core/test-unit/Audit/AuditDifferTests.cs
+++ b/src/core/test-unit/Audit/AuditDifferTests.cs
@@ -123,7 +123,7 @@ namespace RapidCore.UnitTests.Audit
 
             var actual = Record.Exception(() => auditDiffer.GetAuditReadyDiff(oldState, null));
 
-            Assert.IsType<ArgumentException>(actual);
+            Assert.IsType<FailureToResolveException>(actual);
             Assert.Equal("The value masker \"ThrowInContainerValueMasker\" could not be resolved through the container adapter \"TheContainer\". Has it been registered in the container?", actual.Message);
         }
         
@@ -137,7 +137,7 @@ namespace RapidCore.UnitTests.Audit
 
             var actual = Record.Exception(() => auditDiffer.GetAuditReadyDiff(oldState, null));
 
-            Assert.IsType<ArgumentException>(actual);
+            Assert.IsType<FailureToResolveException>(actual);
             Assert.Equal("The value masker \"ReturnNullFromContainerValueMasker\" could not be resolved through the container adapter \"TheContainer\". Has it been registered in the container?", actual.Message);
         }
 


### PR DESCRIPTION
Closes #128 

This introduces code in `AuditDiffer` that handles failures to resolve the specified `value masker`. It captures the failure and produces an `FailureToResolveException` (which I also added) with a helpful message, rather than ending up with the useless NullReferenceException.