### PR TITLE
Remove net46 compile target

### DIFF
--- a/src/core/main/rapidcore.csproj
+++ b/src/core/main/rapidcore.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>RapidCore</RootNamespace>
     <Version>0.22.0</Version>
     <Title>RapidCore</Title>

--- a/src/mongo/main/rapidcore.mongo.csproj
+++ b/src/mongo/main/rapidcore.mongo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>RapidCore.Mongo</RootNamespace>
     <Version>0.22.0</Version>
     <Title>RapidCore.Mongo</Title>

--- a/src/postgresql/main/rapidcore.postgresql.csproj
+++ b/src/postgresql/main/rapidcore.postgresql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>RapidCore.PostgreSql</RootNamespace>
     <Version>0.22.0</Version>
     <Title>RapidCore.PostgreSql</Title>

--- a/src/redis/main/rapidcore.redis.csproj
+++ b/src/redis/main/rapidcore.redis.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>RapidCore.Redis</RootNamespace>
     <Version>0.22.0</Version>
     <Title>RapidCore.Redis</Title>


### PR DESCRIPTION
Removing `.NET 4.6` as a framework target. That version is looong gone and the core based `.NET 5` is on its way fast.

This should also greatly improve the developer experience on non-windows machines.