### PR TITLE
Improvements to the configuration helpers

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+    "MD012": false,
+    "MD033": false,
+    "MD013": false,
+    "MD014": false,
+    "MD024": false,
+    "MD026": false,
+    "MD007": {
+        "indent": 4
+    }
+}

--- a/Build.sh
+++ b/Build.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# stop on first error, as we otherwise end up with
+# weird error messages
+set -e
+
 # Perform the actual build
 dotnet restore
 

--- a/docs/RapidCore.Configuration/Configuration.md
+++ b/docs/RapidCore.Configuration/Configuration.md
@@ -75,11 +75,11 @@ By allowing the config class to check on multiple keys, the following can be don
 In the config classes it is now possible to do `public string Host => myIConfiguration.Get("db_a:host", "db_shared:host", "no host")`.
 
 
-### GetCommaSeparatedList<T>(string key, List<T> defaultValue)
+### GetFromCommaSeparatedList<T>(string key, List<T> defaultValue)
 
 A common case is to have a configuration value that is actually a list of something. Since it (probably) needs to be represented as a string in an environment variable, a _comma separated string_ is an easy pattern.
 
-For this purpose the `GetCommaSeparatedList<T>(string key, List<T> defaultValue)` method exists - note that it also supports trying multiple keys.
+For this purpose the `GetFromCommaSeparatedList<T>(string key, List<T> defaultValue)` method exists - note that it also supports trying multiple keys.
 
 ```json
 {
@@ -90,7 +90,7 @@ For this purpose the `GetCommaSeparatedList<T>(string key, List<T> defaultValue)
 ```csharp
 IConfiguration config = __magic__;
 
-var characters = config.GetCommaSeparatedList("characters", new List<string>(0));
+var characters = config.GetFromCommaSeparatedList("characters", new List<string>(0));
 // 0 = joker
 // 1 = mr. freeze
 // 2 = poison ivy

--- a/docs/RapidCore.Configuration/Configuration.md
+++ b/docs/RapidCore.Configuration/Configuration.md
@@ -5,9 +5,9 @@ It is extremely rare to deal with an application that does not need to read conf
 The common pattern these days - in a world of containerized applications - is to have some default configuration in files and allowing specific config values to be overruled using environment variables.
 
 
-## [Obsolete] `ConfigBase`
+## Extension methods on `IConfiguration`
 
-The abstract `RapidCore.Configuration.ConfigBase` class exists to make it easy to deliver a strict config interface for use in an application.
+RapidCore adds a few extension methods to `IConfiguration`, which allows for easy implementation of config classes.
 
 An example:
 
@@ -26,22 +26,24 @@ public enum ShoutColor
     Purple
 }
 
-public class ShoutConfig : ConfigBase, IShoutConfig
+public class ShoutConfig : IShoutConfig
 {
-    public MyConfig(IConfiguration config) : base(config) {}
+    private readonly IConfiguration config;
 
-    public string WhatToShout => Get("WHAT_TO_SHOUT", "default shout");
-    public int HowManyTimesToShout => Get("HOW_MANY_TIMES_TO_SHOUT", 666);
-    public ShoutColor Color => Get("SHOUT_COLOR", ShoutColor.Purple);
+    public MyConfig(IConfiguration config)
+    {
+        this.config = config;
+    }
+
+    public string WhatToShout => config.Get("WHAT_TO_SHOUT", "default shout");
+    public int HowManyTimesToShout => config.Get("HOW_MANY_TIMES_TO_SHOUT", 666);
+    public ShoutColor Color => config.Get("SHOUT_COLOR", ShoutColor.Purple);
 }
 ```
 
 With the above, our `Shouter` class just needs to depend on `IShoutConfig` and it will automatically get type appropriate configuration values - including defaults. This allows the code to not have to duplicate the parsing/handling of the raw configuration values all over the place.
 
 
-## Extension methods on `IConfiguration`
-
-The logic implemented in `ConfigBase` does not actually need to be in a class. Instead the logic has been moved to extension methods on `Microsoft.Extensions.Configuration.IConfiguration`, which means that it is no longer necessary to extend `ConfigBase` (and it has actually been marked as _obsolete_).
 
 ### Get<T>(string key, T defaultValue)
 
@@ -97,3 +99,45 @@ var characters = config.GetFromCommaSeparatedList("characters", new List<string>
 ```
 
 Notice how it trims and removes empty entries.
+
+
+
+## [Obsolete] `ConfigBase`
+
+The abstract `RapidCore.Configuration.ConfigBase` class exists to make it easy to deliver a strict config interface for use in an application.
+
+An example:
+
+```csharp
+/**
+ * This is an older pattern, which we now consider
+ * to be obsolete.
+ * You should use the IConfiguration extension methods
+ * instead.
+ */
+
+public interface IShoutConfig
+{
+    string WhatToShout { get; }
+    int HowManyTimesToShout { get; }
+    ShoutColor Color { get; }
+}
+
+public enum ShoutColor
+{
+    Red,
+    Green,
+    Purple
+}
+
+public class ShoutConfig : ConfigBase, IShoutConfig
+{
+    public MyConfig(IConfiguration config) : base(config) {}
+
+    public string WhatToShout => Get("WHAT_TO_SHOUT", "default shout");
+    public int HowManyTimesToShout => Get("HOW_MANY_TIMES_TO_SHOUT", 666);
+    public ShoutColor Color => Get("SHOUT_COLOR", ShoutColor.Purple);
+}
+```
+
+With the above, our `Shouter` class just needs to depend on `IShoutConfig` and it will automatically get type appropriate configuration values - including defaults. This allows the code to not have to duplicate the parsing/handling of the raw configuration values all over the place.

--- a/docs/RapidCore.Configuration/Configuration.md
+++ b/docs/RapidCore.Configuration/Configuration.md
@@ -1,0 +1,99 @@
+# Reading configuration values
+
+It is extremely rare to deal with an application that does not need to read configuration values.
+
+The common pattern these days - in a world of containerized applications - is to have some default configuration in files and allowing specific config values to be overruled using environment variables.
+
+
+## [Obsolete] `ConfigBase`
+
+The abstract `RapidCore.Configuration.ConfigBase` class exists to make it easy to deliver a strict config interface for use in an application.
+
+An example:
+
+```csharp
+public interface IShoutConfig
+{
+    string WhatToShout { get; }
+    int HowManyTimesToShout { get; }
+    ShoutColor Color { get; }
+}
+
+public enum ShoutColor
+{
+    Red,
+    Green,
+    Purple
+}
+
+public class ShoutConfig : ConfigBase, IShoutConfig
+{
+    public MyConfig(IConfiguration config) : base(config) {}
+
+    public string WhatToShout => Get("WHAT_TO_SHOUT", "default shout");
+    public int HowManyTimesToShout => Get("HOW_MANY_TIMES_TO_SHOUT", 666);
+    public ShoutColor Color => Get("SHOUT_COLOR", ShoutColor.Purple);
+}
+```
+
+With the above, our `Shouter` class just needs to depend on `IShoutConfig` and it will automatically get type appropriate configuration values - including defaults. This allows the code to not have to duplicate the parsing/handling of the raw configuration values all over the place.
+
+
+## Extension methods on `IConfiguration`
+
+The logic implemented in `ConfigBase` does not actually need to be in a class. Instead the logic has been moved to extension methods on `Microsoft.Extensions.Configuration.IConfiguration`, which means that it is no longer necessary to extend `ConfigBase` (and it has actually been marked as _obsolete_).
+
+### Get<T>(string key, T defaultValue)
+
+This method converts the value hiding behind `key` to `T` or returns `defaultValue` if there was no value to be found.
+
+### Get<T>(IEnumerable<string> keys, T defaultValue)
+
+This method does the same thing as the regular Get, but it attempts to use each key in **in order**. If none of the keys result in a value, then `defaultValue` is returned.
+
+This one also has 2 convenience overloads for either 2 or 3 keys.
+
+The use case that drove this was - specifically - dealing with a service oriented monolith (i.e. 1 executable with multiple services inside that are treated as silos), where each service needed its own database and credentials. To begin with, these systems tend to use 1 database instance, which means that each service would duplicate the host and port of the database instance in their configurations - e.g.
+
+```json
+{
+    "db_a": { "host": "shared_host", "name": "a" },
+    "db_b": { "host": "shared_host", "name": "b" }
+}
+```
+
+By allowing the config class to check on multiple keys, the following can be done to deduplicate the configuration values.
+
+```json
+{
+    "db_shared": { "host": "shared_host" },
+    "db_a": { "name": "a" },
+    "db_b": { "name": "b" }
+}
+```
+
+In the config classes it is now possible to do `public string Host => myIConfiguration.Get("db_a:host", "db_shared:host", "no host")`.
+
+
+### GetCommaSeparatedList<T>(string key, List<T> defaultValue)
+
+A common case is to have a configuration value that is actually a list of something. Since it (probably) needs to be represented as a string in an environment variable, a _comma separated string_ is an easy pattern.
+
+For this purpose the `GetCommaSeparatedList<T>(string key, List<T> defaultValue)` method exists.
+
+```json
+{
+    "characters": "joker, mr. freeze, , poison ivy"
+}
+```
+
+```csharp
+IConfiguration config = __magic__;
+
+var characters = config.GetCommaSeparatedList("characters", new List<string>(0));
+// 0 = joker
+// 1 = mr. freeze
+// 2 = poison ivy
+```
+
+Notice how it trims and removes empty entries.

--- a/docs/RapidCore.Configuration/Configuration.md
+++ b/docs/RapidCore.Configuration/Configuration.md
@@ -79,7 +79,7 @@ In the config classes it is now possible to do `public string Host => myIConfigu
 
 A common case is to have a configuration value that is actually a list of something. Since it (probably) needs to be represented as a string in an environment variable, a _comma separated string_ is an easy pattern.
 
-For this purpose the `GetCommaSeparatedList<T>(string key, List<T> defaultValue)` method exists.
+For this purpose the `GetCommaSeparatedList<T>(string key, List<T> defaultValue)` method exists - note that it also supports trying multiple keys.
 
 ```json
 {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,8 @@ nav:
       - Indexes: MongoDB/Indexes.md
   - Dependency injection:
       - IRapidContainerAdapter: DependencyInjection/IRapidContainerAdapter.md
+  - Configuration:
+      - Reading config values: RapidCore.Configuration/Configuration.md
   - Diffing:
       - Diff object instances: Diffing/StateChangeFinder.md
   - Environment:

--- a/src/core/main/Configuration/ConfigBase.cs
+++ b/src/core/main/Configuration/ConfigBase.cs
@@ -1,6 +1,4 @@
 using System;
-using System.ComponentModel;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 
 namespace RapidCore.Configuration
@@ -12,6 +10,7 @@ namespace RapidCore.Configuration
     /// for your project, but gain easy access to reading config values
     /// from wherever.
     /// </summary>
+    [Obsolete("No longer necessary. The methods have been implemented as extension methods on Microsoft.Extensions.Configuration.IConfiguration")]
     public abstract class ConfigBase
     {
         private readonly IConfiguration configuration;
@@ -23,18 +22,7 @@ namespace RapidCore.Configuration
 
         protected T Get<T>(string key, T defaultValue)
         {
-            var value = configuration[key];
-
-            if (string.IsNullOrEmpty(value))
-            {
-                return defaultValue;
-            }
-
-            if (TypeDescriptor.GetConverter(typeof(T)).IsValid(value))
-            {
-                return (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
-            }
-            return defaultValue;
+            return configuration.Get(key, defaultValue);
         }
     }
 }

--- a/src/core/main/Configuration/ConfigurationGetExtensions.cs
+++ b/src/core/main/Configuration/ConfigurationGetExtensions.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 
 namespace RapidCore.Configuration
@@ -103,6 +105,30 @@ namespace RapidCore.Configuration
             }
 
             return defaultValue;
+        }
+
+        /// <summary>
+        /// Treat a value as a comma separated list of values of some type - or return a default value.
+        ///
+        /// The parsing is as follows:
+        /// 1. the raw value is split by "comma"
+        /// 2. empty values are removed
+        /// 3. each value is trimmed and converted (just like Get would do)
+        /// </summary>
+        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, string key, List<T> defaultValue)
+        {
+            var value = config.Get<string>(key, null);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            return value
+                .Split(new[] {","}, StringSplitOptions.RemoveEmptyEntries)
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Select(x => ConvertOrDefault(x.Trim(), default(T)))
+                .ToList();
         }
     }
 }

--- a/src/core/main/Configuration/ConfigurationGetExtensions.cs
+++ b/src/core/main/Configuration/ConfigurationGetExtensions.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Configuration;
+
+namespace RapidCore.Configuration
+{
+    /// <summary>
+    /// Extensions for _getting_ values from <see cref="IConfiguration"/>
+    /// </summary>
+    public static class ConfigurationGetExtensions
+    {
+        /// <summary>
+        /// Get a specific configuration key value - or default.
+        /// </summary>
+        public static T Get<T>(this IConfiguration config, string key, T defaultValue)
+        {
+            var value = config[key];
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            if (TypeDescriptor.GetConverter(typeof(T)).IsValid(value))
+            {
+                return (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
+            }
+            return defaultValue;
+        }
+    }
+}

--- a/src/core/main/Configuration/ConfigurationGetExtensions.cs
+++ b/src/core/main/Configuration/ConfigurationGetExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.Extensions.Configuration;
 
@@ -8,11 +9,26 @@ namespace RapidCore.Configuration
     /// </summary>
     public static class ConfigurationGetExtensions
     {
+        private static T ConvertOrDefault<T>(string value, T defaultValue)
+        {
+            if (TypeDescriptor.GetConverter(typeof(T)).IsValid(value))
+            {
+                return (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
+            }
+            return defaultValue;
+        }
+        
         /// <summary>
         /// Get a specific configuration key value - or default.
         /// </summary>
         public static T Get<T>(this IConfiguration config, string key, T defaultValue)
         {
+            /*
+             * This method does not call the multiKey version, as that
+             * would require creating an array that we do not really need.
+             * Since the 1-key version is likely to be the most heavily used,
+             * we might as well make it the cheapest version.
+             */
             var value = config[key];
 
             if (string.IsNullOrEmpty(value))
@@ -20,10 +36,72 @@ namespace RapidCore.Configuration
                 return defaultValue;
             }
 
-            if (TypeDescriptor.GetConverter(typeof(T)).IsValid(value))
+            return ConvertOrDefault(value, defaultValue);
+        }
+
+        /// <summary>
+        /// Get a configuration value that can be behind multiple keys - or default.
+        /// The keys are checked _in order_.
+        ///
+        /// This is a convenience overload for Get(string[] keys, T defaultValue).
+        /// </summary>
+        public static T Get<T>(this IConfiguration config, string keyPrimary, string keySecondary, T defaultValue)
+        {
+            return config.Get(new[] {keyPrimary, keySecondary}, defaultValue);
+        }
+        
+        /// <summary>
+        /// Get a configuration value that can be behind multiple keys - or default.
+        /// The keys are checked _in order_.
+        ///
+        /// This is a convenience overload for Get(string[] keys, T defaultValue).
+        /// </summary>
+        public static T Get<T>(this IConfiguration config, string keyPrimary, string keySecondary, string keyTertiary, T defaultValue)
+        {
+            return config.Get(new[] {keyPrimary, keySecondary, keyTertiary}, defaultValue);
+        }
+
+        /// <summary>
+        /// Get a configuration value that can be behind multiple keys - or default.
+        /// The keys are checked _in order_.
+        ///
+        /// The idea behind this, is that you might have a scenario where you have multiple
+        /// specific things that might share a common config value.
+        ///
+        /// Example:
+        /// Multiple databases in code, but actually running on the same host. In this case, you
+        /// probably want to avoid having to duplicate the hostname to every single database config,
+        /// but you want to retain the option of each of them overriding the "shared" value.
+        ///
+        /// Instead of the following, where there is no sharing...
+        /// {
+        ///   "db_a": { "host": "shared_host", "name": "a" },
+        ///   "db_b": { "host": "shared_host", "name": "b" }
+        /// }
+        ///
+        /// You could now have...
+        ///
+        /// {
+        ///   "db_shared": { "host": "shared_host" },
+        ///   "db_a": { "name": "a" },
+        ///   "db_b": { "name": "b" }
+        /// }
+        ///
+        /// And then use:
+        /// config.Get("db_a:host", "db_shared:host", "defaultValue");
+        /// </summary>
+        public static T Get<T>(this IConfiguration config, IEnumerable<string> keys, T defaultValue)
+        {
+            foreach (var key in keys)
             {
-                return (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value);
+                var value = config[key];
+
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return ConvertOrDefault(value, defaultValue);
+                }
             }
+
             return defaultValue;
         }
     }

--- a/src/core/main/Configuration/ConfigurationGetExtensions.cs
+++ b/src/core/main/Configuration/ConfigurationGetExtensions.cs
@@ -108,16 +108,53 @@ namespace RapidCore.Configuration
         }
 
         /// <summary>
+        /// This is a convenience overload for GetCommaSeparatedList(string[] keys, T defaultValue)
+        /// </summary>
+        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, string key, List<T> defaultValue)
+        {
+            var value = config.Get<string>(key, null);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            return value
+                .Split(new[] {","}, StringSplitOptions.RemoveEmptyEntries)
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Select(x => ConvertOrDefault(x.Trim(), default(T)))
+                .ToList();
+        }
+        
+        /// <summary>
+        /// This is a convenience overload for GetCommaSeparatedList(string[] keys, T defaultValue)
+        /// </summary>
+        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, string keyPrimary, string keySecondary, List<T> defaultValue)
+        {
+            return config.GetCommaSeparatedList(new[] {keyPrimary, keySecondary}, defaultValue);
+        }
+        
+        /// <summary>
+        /// This is a convenience overload for GetCommaSeparatedList(string[] keys, T defaultValue)
+        /// </summary>
+        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, string keyPrimary, string keySecondary, string keyTertiary, List<T> defaultValue)
+        {
+            return config.GetCommaSeparatedList(new[] {keyPrimary, keySecondary, keyTertiary}, defaultValue);
+        }
+        
+        
+        /// <summary>
         /// Treat a value as a comma separated list of values of some type - or return a default value.
+        /// The raw value is determined using the Get extension method.
         ///
         /// The parsing is as follows:
         /// 1. the raw value is split by "comma"
         /// 2. empty values are removed
         /// 3. each value is trimmed and converted (just like Get would do)
         /// </summary>
-        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, string key, List<T> defaultValue)
+        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, IEnumerable<string> keys, List<T> defaultValue)
         {
-            var value = config.Get<string>(key, null);
+            var value = config.Get<string>(keys, null);
 
             if (string.IsNullOrEmpty(value))
             {

--- a/src/core/main/Configuration/ConfigurationGetExtensions.cs
+++ b/src/core/main/Configuration/ConfigurationGetExtensions.cs
@@ -108,9 +108,9 @@ namespace RapidCore.Configuration
         }
 
         /// <summary>
-        /// This is a convenience overload for GetCommaSeparatedList(string[] keys, T defaultValue)
+        /// This is a convenience overload for GetFromCommaSeparatedList(string[] keys, List<T> defaultValue)
         /// </summary>
-        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, string key, List<T> defaultValue)
+        public static List<T> GetFromCommaSeparatedList<T>(this IConfiguration config, string key, List<T> defaultValue)
         {
             var value = config.Get<string>(key, null);
 
@@ -127,19 +127,19 @@ namespace RapidCore.Configuration
         }
         
         /// <summary>
-        /// This is a convenience overload for GetCommaSeparatedList(string[] keys, T defaultValue)
+        /// This is a convenience overload for GetFromCommaSeparatedList(string[] keys, List<T> defaultValue)
         /// </summary>
-        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, string keyPrimary, string keySecondary, List<T> defaultValue)
+        public static List<T> GetFromCommaSeparatedList<T>(this IConfiguration config, string keyPrimary, string keySecondary, List<T> defaultValue)
         {
-            return config.GetCommaSeparatedList(new[] {keyPrimary, keySecondary}, defaultValue);
+            return config.GetFromCommaSeparatedList(new[] {keyPrimary, keySecondary}, defaultValue);
         }
         
         /// <summary>
-        /// This is a convenience overload for GetCommaSeparatedList(string[] keys, T defaultValue)
+        /// This is a convenience overload for GetFromCommaSeparatedList(string[] keys, List<T> defaultValue)
         /// </summary>
-        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, string keyPrimary, string keySecondary, string keyTertiary, List<T> defaultValue)
+        public static List<T> GetFromCommaSeparatedList<T>(this IConfiguration config, string keyPrimary, string keySecondary, string keyTertiary, List<T> defaultValue)
         {
-            return config.GetCommaSeparatedList(new[] {keyPrimary, keySecondary, keyTertiary}, defaultValue);
+            return config.GetFromCommaSeparatedList(new[] {keyPrimary, keySecondary, keyTertiary}, defaultValue);
         }
         
         
@@ -152,7 +152,7 @@ namespace RapidCore.Configuration
         /// 2. empty values are removed
         /// 3. each value is trimmed and converted (just like Get would do)
         /// </summary>
-        public static List<T> GetCommaSeparatedList<T>(this IConfiguration config, IEnumerable<string> keys, List<T> defaultValue)
+        public static List<T> GetFromCommaSeparatedList<T>(this IConfiguration config, IEnumerable<string> keys, List<T> defaultValue)
         {
             var value = config.Get<string>(keys, null);
 

--- a/src/test-unit/Core/Configuration/ConfigurationGetExtensionsTests.cs
+++ b/src/test-unit/Core/Configuration/ConfigurationGetExtensionsTests.cs
@@ -232,6 +232,81 @@ namespace UnitTests.Core.Configuration
         }
         #endregion
 
+        #region GetCommaSeparatedList
+        [Fact]
+        public void GetCommaSeparatedList_returns_default_whenKeyDoesNotExist()
+        {
+            var conf = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> {
+                    { "not_this_key", "some value" }
+                }).Build();
+
+            var theDefault = new List<string> { "default" };
+            
+            var actual = conf.GetCommaSeparatedList("pick_me", theDefault);
+            
+            Assert.Same(actual, theDefault);
+            Assert.Single(actual);
+            Assert.Equal("default", actual[0]);
+        }
+        
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetCommaSeparatedList_returns_default_whenKeyExistsButIsNullOrEmpty(string keyValue)
+        {
+            var conf = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> {
+                    { "not_this_key", "some value" },
+                    { "pick_me", keyValue }
+                }).Build();
+
+            var theDefault = new List<string> { "default" };
+            
+            var actual = conf.GetCommaSeparatedList("pick_me", theDefault);
+            
+            Assert.Same(actual, theDefault);
+            Assert.Single(actual);
+            Assert.Equal("default", actual[0]);
+        }
+        
+        [Fact]
+        public void GetCommaSeparatedList_string_returns_trimmedAndSeparated()
+        {
+            var conf = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> {
+                    { "not_this_key", "some value" },
+                    { "pick_me", ", a   , , b,c,d"}
+                }).Build();
+
+            var actual = conf.GetCommaSeparatedList("pick_me", new List<string>(0));
+            
+            Assert.Equal(4, actual.Count);
+            Assert.Equal("a", actual[0]);
+            Assert.Equal("b", actual[1]);
+            Assert.Equal("c", actual[2]);
+            Assert.Equal("d", actual[3]);
+        }
+        
+        [Fact]
+        public void GetCommaSeparatedList_int()
+        {
+            var conf = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> {
+                    { "not_this_key", "some value" },
+                    { "pick_me", ", 1  , , 2,3,4"}
+                }).Build();
+
+            var actual = conf.GetCommaSeparatedList("pick_me", new List<int>(0));
+            
+            Assert.Equal(4, actual.Count);
+            Assert.Equal(1, actual[0]);
+            Assert.Equal(2, actual[1]);
+            Assert.Equal(3, actual[2]);
+            Assert.Equal(4, actual[3]);
+        }
+        #endregion
+
         #region Victims
         private enum MyTestConfigThing
         {

--- a/src/test-unit/Core/Configuration/ConfigurationGetExtensionsTests.cs
+++ b/src/test-unit/Core/Configuration/ConfigurationGetExtensionsTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using RapidCore.Configuration;
+using Xunit;
+
+namespace UnitTests.Core.Configuration
+{
+    public class ConfigurationGetExtensionsTests
+    {
+        private readonly IConfiguration config;
+
+        public ConfigurationGetExtensionsTests()
+        {
+            config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> {
+                    { "string", "from config" },
+                    { "string_null", null },
+                    { "string_empty", string.Empty },
+                    { "int", "3" },
+                    { "int_zero", "0" },
+                    { "section:section-1", "s1 from config" },
+                    { "section:subsection:subsection-1", "subsection 1 from config"},
+                    { "enum", "One" },
+                    { "enum_null", null },
+                    { "enum_empty", string.Empty },
+                    { "enum_invalid", "NotAValidValue" }
+                }).Build();
+        }
+        
+        [Fact]
+        public void Get_String()
+        {
+            Assert.Equal("from config", config.Get<string>("string", "default"));
+        }
+
+        [Fact]
+        public void Get_String_Default_IfNull()
+        {
+            Assert.Equal("default", config.Get<string>("string_null", "default"));
+        }
+
+        [Fact]
+        public void Get_String_Default_IfEmpty()
+        {
+            Assert.Equal("default", config.Get<string>("string_empty", "default"));
+        }
+
+        [Fact]
+        public void Get_String_Default_IfUndefined()
+        {
+            Assert.Equal("default", config.Get<string>("does_not_exist_coz_that_would_be_weird", "default"));
+        }
+
+        [Fact]
+        public void Get_Int()
+        {
+            Assert.Equal(3, config.Get<int>("int", 999));
+        }
+
+        [Fact]
+        public void Get_Int_zeroIsValid()
+        {
+            Assert.Equal(0, config.Get<int>("int_zero", 999));
+        }
+
+        [Fact]
+        public void Get_Int_Default_IfUndefined()
+        {
+            Assert.Equal(999, config.Get<int>("does_not_exist_coz_that_would_be_weird", 999));
+        }
+        
+        [Fact]
+        public void Section_syntax_is_correct()
+        {
+            // tests that the "parsed" json section
+            // syntax used in the contructor of this class
+            // is correct
+
+            var actual = config.GetSection("section");
+            
+            Assert.Equal("s1 from config", actual["section-1"]);
+
+            var subsection = actual.GetSection("subsection");
+            
+            Assert.Equal("subsection 1 from config", subsection["subsection-1"]);
+        }
+        
+        [Fact]
+        public void Get_Section_exists_key_exists()
+        {
+            Assert.Equal("s1 from config", config.Get<string>("section:section-1", "default"));
+        }
+        
+        [Fact]
+        public void Get_Section_if_section_is_undefined_return_default()
+        {
+            Assert.Equal("default", config.Get<string>("no-such-section:yummy", "default"));
+        }
+        
+        [Fact]
+        public void Get_Section_if_key_is_undefined_return_default()
+        {
+            Assert.Equal("default", config.Get<string>("section:yummy", "default"));
+        }
+        
+        [Fact]
+        public void Get_SubSection_exists_key_exists()
+        {
+            Assert.Equal("subsection 1 from config", config.Get<string>("section:subsection:subsection-1", "default"));
+        }
+
+        [Fact]
+        public void Get_Enum()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("enum", MyTestConfigThing.Zero));
+        }
+
+        [Fact]
+        public void Get_Enum_Default_IfNull()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("enum_null", MyTestConfigThing.One));
+        }
+
+        [Fact]
+        public void Get_Enum_Default_IfEmpty()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("enum_empty", MyTestConfigThing.One));
+        }
+
+        [Fact]
+        public void Get_Enum_Default_IfUndefined()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("does_not_exist_coz_that_would_be_weird", MyTestConfigThing.One));
+        }
+        
+        [Fact]
+        public void Get_Enum_Default_IfInvalidValue()
+        {
+            Assert.Equal(MyTestConfigThing.One, config.Get<MyTestConfigThing>("enum_invalid", MyTestConfigThing.One));
+        }
+
+        #region Victims
+        private enum MyTestConfigThing
+        {
+            Zero = 0,
+            One = 1
+        }
+        #endregion
+    }
+}

--- a/src/test-unit/Core/Configuration/ConfigurationGetExtensionsTests.cs
+++ b/src/test-unit/Core/Configuration/ConfigurationGetExtensionsTests.cs
@@ -232,9 +232,9 @@ namespace UnitTests.Core.Configuration
         }
         #endregion
 
-        #region GetCommaSeparatedList (single key)
+        #region GetFromCommaSeparatedList (single key)
         [Fact]
-        public void GetCommaSeparatedList_returns_default_whenKeyDoesNotExist()
+        public void GetFromCommaSeparatedList_returns_default_whenKeyDoesNotExist()
         {
             var conf = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string> {
@@ -243,7 +243,7 @@ namespace UnitTests.Core.Configuration
 
             var theDefault = new List<string> { "default" };
             
-            var actual = conf.GetCommaSeparatedList("pick_me", theDefault);
+            var actual = conf.GetFromCommaSeparatedList("pick_me", theDefault);
             
             Assert.Same(actual, theDefault);
             Assert.Single(actual);
@@ -253,7 +253,7 @@ namespace UnitTests.Core.Configuration
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void GetCommaSeparatedList_returns_default_whenKeyExistsButIsNullOrEmpty(string keyValue)
+        public void GetFromCommaSeparatedList_returns_default_whenKeyExistsButIsNullOrEmpty(string keyValue)
         {
             var conf = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string> {
@@ -263,7 +263,7 @@ namespace UnitTests.Core.Configuration
 
             var theDefault = new List<string> { "default" };
             
-            var actual = conf.GetCommaSeparatedList("pick_me", theDefault);
+            var actual = conf.GetFromCommaSeparatedList("pick_me", theDefault);
             
             Assert.Same(actual, theDefault);
             Assert.Single(actual);
@@ -271,7 +271,7 @@ namespace UnitTests.Core.Configuration
         }
         
         [Fact]
-        public void GetCommaSeparatedList_string_returns_trimmedAndSeparated()
+        public void GetFromCommaSeparatedList_string_returns_trimmedAndSeparated()
         {
             var conf = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string> {
@@ -279,7 +279,7 @@ namespace UnitTests.Core.Configuration
                     { "pick_me", ", a   , , b,c,d"}
                 }).Build();
 
-            var actual = conf.GetCommaSeparatedList("pick_me", new List<string>(0));
+            var actual = conf.GetFromCommaSeparatedList("pick_me", new List<string>(0));
             
             Assert.Equal(4, actual.Count);
             Assert.Equal("a", actual[0]);
@@ -289,7 +289,7 @@ namespace UnitTests.Core.Configuration
         }
         
         [Fact]
-        public void GetCommaSeparatedList_int()
+        public void GetFromCommaSeparatedList_int()
         {
             var conf = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string> {
@@ -297,7 +297,7 @@ namespace UnitTests.Core.Configuration
                     { "pick_me", ", 1  , , 2,3,4"}
                 }).Build();
 
-            var actual = conf.GetCommaSeparatedList("pick_me", new List<int>(0));
+            var actual = conf.GetFromCommaSeparatedList("pick_me", new List<int>(0));
             
             Assert.Equal(4, actual.Count);
             Assert.Equal(1, actual[0]);
@@ -307,7 +307,7 @@ namespace UnitTests.Core.Configuration
         }
         #endregion
 
-        #region GetCommaSeparatedList (multi key)
+        #region GetFromCommaSeparatedList (multi key)
         [Theory]
         [InlineData("1", "2", "default", "1")]
         [InlineData("   ", "2", "default", "--empty--")] // whitespace is a valid value
@@ -317,7 +317,7 @@ namespace UnitTests.Core.Configuration
         [InlineData(null, "  ", "default", "--empty--")] // whitespace is a valid value
         // no keys set
         [InlineData(null, null, "default", "default")]
-        public void GetCommaSeparatedList_2keys_respectsOrdering(string primaryValue, string secondaryValue, string defaultValue, string expected)
+        public void GetFromCommaSeparatedList_2keys_respectsOrdering(string primaryValue, string secondaryValue, string defaultValue, string expected)
         {
             var conf = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string> {
@@ -325,7 +325,7 @@ namespace UnitTests.Core.Configuration
                     { "secondary", secondaryValue }
                 }).Build();
 
-            var actual = conf.GetCommaSeparatedList("primary", "secondary", new List<string> { defaultValue });
+            var actual = conf.GetFromCommaSeparatedList("primary", "secondary", new List<string> { defaultValue });
 
             if (expected.Equals("--empty--"))
             {
@@ -352,7 +352,7 @@ namespace UnitTests.Core.Configuration
         // no keys set
         [InlineData(null, null, null, "default", "default")]
         [InlineData(null, null, "", "default", "default")]
-        public void GetCommaSeparatedList_3keys_respectsOrdering(string primaryValue, string secondaryValue, string tertiaryValue, string defaultValue, string expected)
+        public void GetFromCommaSeparatedList_3keys_respectsOrdering(string primaryValue, string secondaryValue, string tertiaryValue, string defaultValue, string expected)
         {
             var conf = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string> {
@@ -361,7 +361,7 @@ namespace UnitTests.Core.Configuration
                     { "tertiary", tertiaryValue }
                 }).Build();
 
-            var actual = conf.GetCommaSeparatedList("primary", "secondary", "tertiary", new List<string> { defaultValue });
+            var actual = conf.GetFromCommaSeparatedList("primary", "secondary", "tertiary", new List<string> { defaultValue });
 
             if (expected.Equals("--empty--"))
             {

--- a/src/test-unit/Core/Configuration/ConfigurationGetExtensionsTests.cs
+++ b/src/test-unit/Core/Configuration/ConfigurationGetExtensionsTests.cs
@@ -232,7 +232,7 @@ namespace UnitTests.Core.Configuration
         }
         #endregion
 
-        #region GetCommaSeparatedList
+        #region GetCommaSeparatedList (single key)
         [Fact]
         public void GetCommaSeparatedList_returns_default_whenKeyDoesNotExist()
         {
@@ -304,6 +304,74 @@ namespace UnitTests.Core.Configuration
             Assert.Equal(2, actual[1]);
             Assert.Equal(3, actual[2]);
             Assert.Equal(4, actual[3]);
+        }
+        #endregion
+
+        #region GetCommaSeparatedList (multi key)
+        [Theory]
+        [InlineData("1", "2", "default", "1")]
+        [InlineData("   ", "2", "default", "--empty--")] // whitespace is a valid value
+        // primary not set
+        [InlineData(null, "2", "default", "2")]
+        [InlineData("", "2", "default", "2")]
+        [InlineData(null, "  ", "default", "--empty--")] // whitespace is a valid value
+        // no keys set
+        [InlineData(null, null, "default", "default")]
+        public void GetCommaSeparatedList_2keys_respectsOrdering(string primaryValue, string secondaryValue, string defaultValue, string expected)
+        {
+            var conf = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> {
+                    { "primary", primaryValue },
+                    { "secondary", secondaryValue }
+                }).Build();
+
+            var actual = conf.GetCommaSeparatedList("primary", "secondary", new List<string> { defaultValue });
+
+            if (expected.Equals("--empty--"))
+            {
+                Assert.Empty(actual);
+            }
+            else
+            {
+                Assert.Single(actual);
+                Assert.Equal(expected, actual[0]);
+            }
+        }
+
+        [Theory]
+        [InlineData("1", "2", "3", "default", "1")]
+        [InlineData("   ", "2", "3", "default", "--empty--")] // whitespace is a valid value
+        // primary not set
+        [InlineData(null, "2", "3", "default", "2")]
+        [InlineData("", "2", "3", "default", "2")]
+        [InlineData(null, "  ", "3", "default", "--empty--")] // whitespace is a valid value
+        // primary and secondary not set
+        [InlineData(null, null, "3", "default", "3")]
+        [InlineData(null, "", "3", "default", "3")]
+        [InlineData(null, null, "   ", "default", "--empty--")] // whitespace is a valid value
+        // no keys set
+        [InlineData(null, null, null, "default", "default")]
+        [InlineData(null, null, "", "default", "default")]
+        public void GetCommaSeparatedList_3keys_respectsOrdering(string primaryValue, string secondaryValue, string tertiaryValue, string defaultValue, string expected)
+        {
+            var conf = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> {
+                    { "primary", primaryValue },
+                    { "secondary", secondaryValue },
+                    { "tertiary", tertiaryValue }
+                }).Build();
+
+            var actual = conf.GetCommaSeparatedList("primary", "secondary", "tertiary", new List<string> { defaultValue });
+
+            if (expected.Equals("--empty--"))
+            {
+                Assert.Empty(actual);
+            }
+            else
+            {
+                Assert.Single(actual);
+                Assert.Equal(expected, actual[0]);
+            }
         }
         #endregion
 


### PR DESCRIPTION
Lately I have spotted some possible improvements to the configuration helper(s).

1. have had multiple cases where I would have liked to have been able to have a shared config value as a fallback - i.e. being able to do something like `Get("specific_key", "fallback_key", "default value")`
2. have implemented handling of comma separated values multiple times (get value as string, split it, clean it up then convert it to a list)
3. started thinking that maybe the `ConfigBase` is not really needed as all it contains is a method that uses the `IConfiguration` that it is given - but that logic could just as easily be implemented as an extension method on the `IConfiguration` as it does not need to be mockable (we would always mock the interface/class itself anyway)

This MR addresses all of the above + adds documentation of it :)