### PR TITLE
Custom xunit assertions

### DIFF
--- a/src/test-unit/Xunit/Assertions/ContainsTheSameElementsTests.cs
+++ b/src/test-unit/Xunit/Assertions/ContainsTheSameElementsTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using RapidCore.Xunit.Assertions;
+using Xunit;
+using Xunit.Sdk;
+
+namespace UnitTests.Xunit.Assertions
+{
+    public class ContainsTheSameElementsTests
+    {
+        [Fact]
+        public void ContainsTheSameElements_complains_if_a_is_null()
+        {
+            try
+            {
+                RapidCoreAssert.ContainsTheSameElements(null, new int[0]);
+                RapidCoreAssert.Fail("we should have got a complaint about 'a' being null");
+            }
+            catch (NotNullException)
+            {
+                // yay
+            }
+        }
+
+
+        [Fact]
+        public void ContainsTheSameElements_complains_if_b_is_null()
+        {
+            try
+            {
+                RapidCoreAssert.ContainsTheSameElements(new int[0], null);
+                RapidCoreAssert.Fail("we should have got a complaint about 'b' being null");
+            }
+            catch (NotNullException)
+            {
+                // yay
+            }
+        }
+
+
+        [Fact]
+        public void ContainsTheSameElements_failsIfCollectionsHaveDifferentNumberOfElements()
+        {
+            try
+            {
+                RapidCoreAssert.ContainsTheSameElements(new[] {1, 2}, new[] {1, 2, 3});
+                RapidCoreAssert.Fail("collections have different number of elements");
+            }
+            catch (EqualException)
+            {
+                // yay
+            }
+        }
+
+        [Fact]
+        public void ContainsTheSameElements_failsIfCollectionsHaveDifferentElements()
+        {
+            try
+            {
+                var item1 = new Victim {Id = "1"};
+                var item2 = new Victim {Id = "2"};
+                var item3 = new Victim {Id = "3"};
+
+                var a = new List<Victim> {item1, item2};
+                var b = new List<Victim> {item1, item3};
+
+                RapidCoreAssert.ContainsTheSameElements(a, b);
+                RapidCoreAssert.Fail("collections have different elements");
+            }
+            catch (ContainsException)
+            {
+                // yay
+            }
+        }
+
+
+        [Fact]
+        public void ContainsTheSameElements_works_whenCollectionsHaveTheSameElements_inTheSameOrder()
+        {
+            var item1 = new Victim {Id = "1"};
+            var item2 = new Victim {Id = "2"};
+
+            var a = new List<Victim> {item1, item2};
+            var b = new List<Victim> {item1, item2};
+
+            RapidCoreAssert.ContainsTheSameElements(a, b);
+        }
+
+
+        [Fact]
+        public void ContainsTheSameElements_works_whenCollectionsHaveTheSameElements_inDifferentOrder()
+        {
+            var item1 = new Victim {Id = "1"};
+            var item2 = new Victim {Id = "2"};
+
+            var a = new List<Victim> {item1, item2};
+            var b = new List<Victim> {item2, item1};
+
+            RapidCoreAssert.ContainsTheSameElements(a, b);
+        }
+
+
+        #region Victims
+
+        private class Victim
+        {
+            public string Id { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/src/xunit/main/Assertions/FailXunitException.cs
+++ b/src/xunit/main/Assertions/FailXunitException.cs
@@ -1,0 +1,14 @@
+using Xunit.Sdk;
+
+namespace RapidCore.Xunit.Assertions
+{
+    /// <summary>
+    /// The exception to throw from <see cref="RapidCoreAssert.Fail"/>
+    /// </summary>
+    public class FailXunitException : XunitException
+    {
+        public FailXunitException(string reason) : base($"Forced failure: {reason}")
+        {
+        }
+    }
+}

--- a/src/xunit/main/Assertions/Partials/ContainsTheSameElements.cs
+++ b/src/xunit/main/Assertions/Partials/ContainsTheSameElements.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace RapidCore.Xunit.Assertions
+{
+    public static partial class RapidCoreAssert
+    {
+        /// <summary>
+        /// Verify that 2 collections contain the _same_ elements
+        /// </summary>
+        /// <param name="a">The first collection</param>
+        /// <param name="b">The second collection</param>
+        /// <typeparam name="T">The type of element in the collections</typeparam>
+        public static void ContainsTheSameElements<T>(IEnumerable<T> a, IEnumerable<T> b)
+        {
+            Assert.NotNull(a);
+            Assert.NotNull(b);
+            
+            Assert.Equal(a.Count(), b.Count());
+
+            // using a loop and Assert.Contains instead
+            // of Assert.All as this method gives more
+            // useful hint of what is wrong with the collections.
+            foreach (var inA in a)
+            {
+                Assert.Contains(inA, b);
+            }
+        }
+    }
+}

--- a/src/xunit/main/Assertions/Partials/Fail.cs
+++ b/src/xunit/main/Assertions/Partials/Fail.cs
@@ -1,0 +1,18 @@
+namespace RapidCore.Xunit.Assertions
+{
+    public static partial class RapidCoreAssert
+    {
+        /// <summary>
+        /// Make a test fail.
+        ///
+        /// This is useful when a line in a test should
+        /// never be reached - e.g. when testing exception
+        /// handling with try..catch
+        /// </summary>
+        /// <param name="reason">The reason why this should fail</param>
+        public static void Fail(string reason)
+        {
+            throw new FailXunitException(reason);
+        }
+    }
+}

--- a/src/xunit/main/Assertions/RapidCoreAssert.cs
+++ b/src/xunit/main/Assertions/RapidCoreAssert.cs
@@ -1,0 +1,6 @@
+namespace RapidCore.Xunit.Assertions
+{
+    public static partial class RapidCoreAssert
+    {
+    }
+}

--- a/src/xunit/main/rapidcore.xunit.csproj
+++ b/src/xunit/main/rapidcore.xunit.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
+    <PackageReference Include="xunit.assert" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\main\rapidcore.csproj" />


### PR DESCRIPTION
I came across some code today that needed to assert that 2 collections contained the exact same elements. To get the most semantic code possible I decided to write an assertion that uses multiple assertions from `Xunit` under the hood.

I have also always felt that `Fail` was missing from Xunit, as I find it much more semantic than `Assert.True(false)` which provides no explanation (or the slightly more useful `Assert.Null("reason this should not be reached")`.

What do you guys think? Is it useful?

I have not yet looked into if there is a better way of "extending" the assertions of Xunit and I have also not added any documentation at this point, so the code is definitely not ready to be merged.