### PR TITLE
Use redis connection pool for Redis Lock Provider

### DIFF
--- a/src/core/main/Globalization/Iso4217Currencies.cs
+++ b/src/core/main/Globalization/Iso4217Currencies.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace RapidCore.Globalization

--- a/src/core/main/IO/FileSystem/DotNetFileSystemProvider.cs
+++ b/src/core/main/IO/FileSystem/DotNetFileSystemProvider.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace RapidCore.IO.FileSystem
 {

--- a/src/core/main/IO/FileSystem/SftpClient.cs
+++ b/src/core/main/IO/FileSystem/SftpClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Renci.SshNet;
-using Renci.SshNet.Sftp;
 
 namespace RapidCore.IO.FileSystem
 {

--- a/src/core/main/IO/FileSystem/SftpFileSystemProvider.cs
+++ b/src/core/main/IO/FileSystem/SftpFileSystemProvider.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using Renci.SshNet;
 
 namespace RapidCore.IO.FileSystem
 {

--- a/src/core/main/Security/RandomNumberGeneratorGuid.cs
+++ b/src/core/main/Security/RandomNumberGeneratorGuid.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace RapidCore.Security
 {

--- a/src/mongo/test-functional/MongoDbConnectionTests.cs
+++ b/src/mongo/test-functional/MongoDbConnectionTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;

--- a/src/mongo/test-functional/MongoDbConnection_GetCollection_Tests.cs
+++ b/src/mongo/test-functional/MongoDbConnection_GetCollection_Tests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 using RapidCore.Mongo.Testing;
 using Xunit;

--- a/src/mongo/test-functional/MongoDbConnection_Insert_Tests.cs
+++ b/src/mongo/test-functional/MongoDbConnection_Insert_Tests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 using RapidCore.Mongo.Testing;
 using Xunit;

--- a/src/mongo/test-functional/MongoManagerTests/EnsureIndexesWithCustomCollectionNameTests.cs
+++ b/src/mongo/test-functional/MongoManagerTests/EnsureIndexesWithCustomCollectionNameTests.cs
@@ -1,7 +1,4 @@
-using System.Reflection;
 using MongoDB.Bson;
-using MongoDB.Driver;
-using RapidCore.Mongo.Internal;
 using Xunit;
 
 namespace RapidCore.Mongo.FunctionalTests.MongoManagerTests

--- a/src/redis/main/Locking/RedisDistributedAppLockProvider.cs
+++ b/src/redis/main/Locking/RedisDistributedAppLockProvider.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using RapidCore.Locking;
-using StackExchange.Redis;
 using StackExchange.Redis.Extensions.Core.Abstractions;
 
 namespace RapidCore.Redis.Locking

--- a/src/redis/main/rapidcore.redis.csproj
+++ b/src/redis/main/rapidcore.redis.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.*" />
+    <PackageReference Include="StackExchange.Redis.Extensions.Core" Version="5.5.0" />
   </ItemGroup>
   
   

--- a/src/redis/test-functional/Locking/RedisDistributedAppLockProviderTest.cs
+++ b/src/redis/test-functional/Locking/RedisDistributedAppLockProviderTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using RapidCore.Locking;
 using RapidCore.Redis.Locking;
-using StackExchange.Redis;
 using StackExchange.Redis.Extensions.Core.Configuration;
 using StackExchange.Redis.Extensions.Core.Implementations;
 using Xunit;

--- a/src/redis/test-functional/Migration/MigrationTests.cs
+++ b/src/redis/test-functional/Migration/MigrationTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using FakeItEasy;

--- a/src/redis/test-functional/Migration/YoloMigrationRunnerTests .cs
+++ b/src/redis/test-functional/Migration/YoloMigrationRunnerTests .cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using FakeItEasy;

--- a/src/sqlserver/main/Locking/SqlServerDistributedAppLock.cs
+++ b/src/sqlserver/main/Locking/SqlServerDistributedAppLock.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Data;
-using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
 using RapidCore.Locking;

--- a/src/sqlserver/main/Locking/SqlServerDistributedAppLockProvider.cs
+++ b/src/sqlserver/main/Locking/SqlServerDistributedAppLockProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Data;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using RapidCore.Locking;
 using RapidCore.Threading;

--- a/src/test-unit/Redis/Locking/RedisDistributedAppLockProviderTest.cs
+++ b/src/test-unit/Redis/Locking/RedisDistributedAppLockProviderTest.cs
@@ -2,6 +2,7 @@ using System;
 using FakeItEasy;
 using RapidCore.Redis.Locking;
 using StackExchange.Redis;
+using StackExchange.Redis.Extensions.Core.Abstractions;
 using Xunit;
 
 namespace UnitTests.Redis.Locking
@@ -14,17 +15,21 @@ namespace UnitTests.Redis.Locking
             var lockName = "the-lock";
             
             var client = A.Fake<IDatabase>();
+            var pool = A.Fake<IRedisCacheConnectionPoolManager>();
             var manager = A.Fake<IConnectionMultiplexer>();
+            
+            A.CallTo(() => pool.GetConnection()).Returns(manager);
             A.CallTo(() => manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).Returns(client);
             A.CallTo(() => client.LockTake(
                 A<RedisKey>.That.Matches(str => str == lockName),
                 A<RedisValue>.Ignored,
                 A<TimeSpan>.Ignored,
                 A<CommandFlags>.Ignored)).Returns(true);
-            var locker = new RedisDistributedAppLockProvider(manager);
+            var locker = new RedisDistributedAppLockProvider(pool);
 
             locker.Acquire(lockName);
 
+            A.CallTo(() => pool.GetConnection()).MustHaveHappened();
             A.CallTo(() => manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).MustHaveHappened();
         }
         
@@ -35,14 +40,17 @@ namespace UnitTests.Redis.Locking
             var lockName = "the-lock";
             
             var client = A.Fake<IDatabase>();
+            var pool = A.Fake<IRedisCacheConnectionPoolManager>();
             var manager = A.Fake<IConnectionMultiplexer>();
+            
+            A.CallTo(() => pool.GetConnection()).Returns(manager);
             A.CallTo(() => manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).Returns(client);
             A.CallTo(() => client.LockTake(
                 A<RedisKey>.That.Matches(str => str == lockName),
                 A<RedisValue>.Ignored,
                 A<TimeSpan>.Ignored,
                 A<CommandFlags>.Ignored)).Returns(true);
-            var locker = new RedisDistributedAppLockProvider(manager);
+            var locker = new RedisDistributedAppLockProvider(pool);
 
             locker.Acquire(lockName);
 

--- a/src/xunit/main/Logging/XunitOutputLogger.cs
+++ b/src/xunit/main/Logging/XunitOutputLogger.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 

--- a/src/xunit/main/Logging/XunitOutputLoggerProvider.cs
+++ b/src/xunit/main/Logging/XunitOutputLoggerProvider.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 

--- a/src/xunit/main/Logging/XunitOutputLoggerProviderExtension.cs
+++ b/src/xunit/main/Logging/XunitOutputLoggerProviderExtension.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
 namespace RapidCore.Xunit.Logging


### PR DESCRIPTION
This PR installs the `StackExchange.Redis.Extensions.Core` version 5.5.0 (which is not the latest, read below) in order to use a Redis Connection Pool of Connection Multiplexers to achieve higher lock-take concurrency for busy systems.

version 5.5.0 of the package has been selected as the 6.x series requires dotnet core app 3.1 and our customer in trouble is still on 2.2. Upgrading the package can be tracked in a new issue as we should be using the latest version.

This is a breaking change as our Redis Lock Provider no longer requires the `IConnectionMultiplexer` to be registered in the container, but rather a `IRedisCacheConnectionPoolManager`

Closes #172