### PR TITLE
Throw exception if given instance that cannot be traversed

### DIFF
--- a/docs/RapidCore.Reflection/InstanceTraverser.md
+++ b/docs/RapidCore.Reflection/InstanceTraverser.md
@@ -2,7 +2,7 @@
 
 Traversing an instance of an object is useful in many reflection based tasks, but it has a bunch of pitfalls and requires a seemingly infinite amount of tests.
 
-Instead of repeating a bunch of these things every time we build something with reflection, we now have `RapidCore.Reflection.InstanceTraverser`, which can traverse an instance of an object.
+Instead of repeating a bunch of these things every time we build something with reflection, we now have `RapidCore.Reflection.InstanceTraverser`, which can traverse an instance of an object. It will throw an exception if given an instance of a type that it cannot traverse (e.g. decimal, DateTime, Streams etc.).
 
 It will:
 

--- a/src/core/main/Reflection/InstanceTraversalException.cs
+++ b/src/core/main/Reflection/InstanceTraversalException.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace RapidCore.Reflection
+{
+    [Serializable]
+    public class InstanceTraversalException : Exception
+    {
+        public InstanceTraversalException(string message) : base(message)
+        {
+        }
+
+        public InstanceTraversalException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/core/main/Reflection/InstanceTraverser.cs
+++ b/src/core/main/Reflection/InstanceTraverser.cs
@@ -28,6 +28,11 @@ namespace RapidCore.Reflection
         /// <param name="listener">The listener that will be notified when we find something</param>
         public virtual void TraverseInstance(object instance, int maxDepth, IInstanceListener listener)
         {
+            if (!ShouldRecurse(instance.GetType()))
+            {
+                throw new InstanceTraversalException($"{instance.GetType()} is not a type that can be traversed.");
+            }
+            
             var context = new InstanceTraversalContext
             {
                 Instance = instance,

--- a/src/test-unit/Core/Reflection/InstanceTraverserTests/InstanceTraverser_BasicTests.cs
+++ b/src/test-unit/Core/Reflection/InstanceTraverserTests/InstanceTraverser_BasicTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using FakeItEasy;
@@ -10,6 +12,40 @@ namespace UnitTests.Core.Reflection.InstanceTraverserTests
 {
     public class InstanceTraverser_BasicTests : InstanceTraverserTestBase
     {
+        public static IEnumerable<object[]> Throws_ifGivenANonTraversable_instance_data()
+        {
+            return new List<object[]>
+            {
+                new [] { (object)StringSplitOptions.RemoveEmptyEntries },
+                new [] { new MemoryStream() },
+                new [] { (object)'c' },
+                new [] { (object)true },
+                new [] { (object)0x12 },
+                new [] { (object)(short)3 },
+                new [] { (object)5 },
+                new [] { (object)7L },
+                new [] { (object)12.34F },
+                new [] { (object)56.37D },
+                new [] { (object)1234m },
+                new [] { (object)DateTime.UtcNow },
+                new [] { (object)DateTimeOffset.UtcNow },
+                new [] { (object)TimeSpan.FromSeconds(666) },
+                new [] { (object)Guid.NewGuid() },
+                new [] { (object)"string" },
+                new [] { (object)(int?)5}
+            };
+        }
+        
+        [Theory]
+        [MemberData(nameof(Throws_ifGivenANonTraversable_instance_data))]
+        public void Throws_ifGivenANonTraversable_instance(object instance)
+        {
+            var actual = Record.Exception(() => Traverser.TraverseInstance(instance, 10, listener));
+            
+            Assert.NotNull(actual);
+            Assert.IsType<InstanceTraversalException>(actual);
+        }
+        
         [Fact]
         public void EventHandlersAreCalled()
         {


### PR DESCRIPTION
The `InstanceTraverser` is designed to traverse instances (i.e. classes with fields and properties), but it did not block cases where it was given non-traversable instances - e.g. being giving a decimal. This turned out to make the reflection go crazy and use a lot of CPU and memory for relatively long time.

This PR adds an explicit block in the `InstanceTraverser` making it throw an `InstanceTraversalException` if given something that it would not dare to recurse into either (basically reusing the logic it uses internally to figure out if it should recurse into a field/property).

I did not manage to find a way to make the `AuditDiffer` handle the situation automatically as it returns an instance of `StateChanges` which contains the specific changes for members - including `MemberInfo` which we would not be able to provide if we just created the changes by hand using just the given values for new and old. This would - likely - lead to annoying situations down the line where code expecting the MemberInfo to be there (because, why would it not be) to run into null references.

I do not consider this a breaking change, as it throws an exception with a - hopefully - useful message rather than running into weird and undefined behavior. It is not blocking something that worked before.

Fixes #177 