### PR TITLE
Depend on latest StackExchange.Redis.Extensions.Core 6.x series

### DIFF
--- a/src/redis/main/Locking/RedisDistributedAppLock.cs
+++ b/src/redis/main/Locking/RedisDistributedAppLock.cs
@@ -66,7 +66,7 @@ namespace RapidCore.Redis.Locking
                 stopWatch.Start();
                 do
                 {
-                    var lockWasAcquired = _redisDb.LockTake(lockName, LockHandle, lockAutoExpireTimeout.Value);
+                    var lockWasAcquired = await _redisDb.LockTakeAsync(lockName, LockHandle, lockAutoExpireTimeout.Value);
 
                     if (!lockWasAcquired && !timeoutProvided)
                     {

--- a/src/redis/main/Locking/RedisDistributedAppLockProvider.cs
+++ b/src/redis/main/Locking/RedisDistributedAppLockProvider.cs
@@ -42,11 +42,13 @@ namespace RapidCore.Redis.Locking
             try
             {
                 // wait for task to complete
-                return task.Result;
+                return task.GetAwaiter().GetResult();
             }
             catch (AggregateException exception)
             {
-                throw exception.Flatten().InnerException;
+                var innerException = exception.Flatten().InnerException;
+                if (innerException != null) throw innerException;
+                throw;
             }
         }
 

--- a/src/redis/main/rapidcore.redis.csproj
+++ b/src/redis/main/rapidcore.redis.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.*" />
-    <PackageReference Include="StackExchange.Redis.Extensions.Core" Version="5.5.0" />
+    <PackageReference Include="StackExchange.Redis.Extensions.Core" Version="6.*" />
   </ItemGroup>
   
   

--- a/src/test-unit/Redis/Locking/RedisDistributedAppLockProviderTest.cs
+++ b/src/test-unit/Redis/Locking/RedisDistributedAppLockProviderTest.cs
@@ -20,7 +20,7 @@ namespace UnitTests.Redis.Locking
             
             A.CallTo(() => pool.GetConnection()).Returns(manager);
             A.CallTo(() => manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).Returns(client);
-            A.CallTo(() => client.LockTake(
+            A.CallTo(() => client.LockTakeAsync(
                 A<RedisKey>.That.Matches(str => str == lockName),
                 A<RedisValue>.Ignored,
                 A<TimeSpan>.Ignored,
@@ -45,7 +45,7 @@ namespace UnitTests.Redis.Locking
             
             A.CallTo(() => pool.GetConnection()).Returns(manager);
             A.CallTo(() => manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).Returns(client);
-            A.CallTo(() => client.LockTake(
+            A.CallTo(() => client.LockTakeAsync(
                 A<RedisKey>.That.Matches(str => str == lockName),
                 A<RedisValue>.Ignored,
                 A<TimeSpan>.Ignored,
@@ -54,7 +54,7 @@ namespace UnitTests.Redis.Locking
 
             locker.Acquire(lockName);
 
-            A.CallTo(() => client.LockTake(
+            A.CallTo(() => client.LockTakeAsync(
                 A<RedisKey>.That.Matches(key => key == lockName),
                 A<RedisValue>.Ignored,
                 A<TimeSpan>.Ignored,

--- a/src/test-unit/Redis/Locking/RedisDistributedAppLockTest.cs
+++ b/src/test-unit/Redis/Locking/RedisDistributedAppLockTest.cs
@@ -22,7 +22,7 @@ namespace UnitTests.Redis.Locking
             _client = A.Fake<IDatabase>(o => o.Strict());
             _manager = A.Fake<IConnectionMultiplexer>(o => o.Strict());
             A.CallTo(() => _manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).Returns(_client);
-            A.CallTo(() => _client.LockTake(
+            A.CallTo(() => _client.LockTakeAsync(
                 A<RedisKey>.That.Matches(str => str == _defaultLockName),
                 A<RedisValue>.Ignored,
                 A<TimeSpan>.Ignored,
@@ -39,7 +39,7 @@ namespace UnitTests.Redis.Locking
             var handle = new RedisDistributedAppLock(_manager, _rng);
             await handle.AcquireLockAsync(_defaultLockName);
 
-            A.CallTo(() => _client.LockTake(
+            A.CallTo(() => _client.LockTakeAsync(
                     A<RedisKey>.That.Matches(str => str == _defaultLockName),
                     A<RedisValue>.Ignored,
                     A<TimeSpan>.Ignored,
@@ -55,7 +55,7 @@ namespace UnitTests.Redis.Locking
             var handle = new RedisDistributedAppLock(_manager, _rng);
             await handle.AcquireLockAsync(_defaultLockName, TimeSpan.MaxValue, TimeSpan.FromSeconds(2));
             
-            A.CallTo(() => _client.LockTake(
+            A.CallTo(() => _client.LockTakeAsync(
                     A<RedisKey>.That.Matches(str => str == _defaultLockName),
                     A<RedisValue>.Ignored,
                     TimeSpan.FromSeconds(2),
@@ -117,7 +117,7 @@ namespace UnitTests.Redis.Locking
             var manager = A.Fake<IConnectionMultiplexer>();
             A.CallTo(() => manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).Returns(client);
 
-            A.CallTo(() => client.LockTake(
+            A.CallTo(() => client.LockTakeAsync(
                  A<RedisKey>.That.Matches(str => str == lockName),
                  A<RedisValue>.Ignored,
                  A<TimeSpan>.Ignored,
@@ -140,7 +140,7 @@ namespace UnitTests.Redis.Locking
             A.CallTo(() => manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).Returns(client);
 
             var exceptionThrownDuringTest = new TimeoutException("test is faking it!");
-            A.CallTo(() => client.LockTake(
+            A.CallTo(() => client.LockTakeAsync(
                  A<RedisKey>.That.Matches(str => str == lockName),
                  A<RedisValue>.Ignored,
                  A<TimeSpan>.Ignored,
@@ -166,7 +166,7 @@ namespace UnitTests.Redis.Locking
             var manager = A.Fake<IConnectionMultiplexer>();
             A.CallTo(() => manager.GetDatabase(A<int>.Ignored, A<object>.Ignored)).Returns(client);
 
-            A.CallTo(() => client.LockTake(
+            A.CallTo(() => client.LockTakeAsync(
                  A<RedisKey>.That.Matches(str => str == lockName),
                  A<RedisValue>.Ignored,
                  A<TimeSpan>.Ignored,


### PR DESCRIPTION
This PR
- updates the stackexchange redis extensions package to the latest major series
- uses `lock take async` to be better async
- fixes sync wait flow for `LockProvider.Acquire` 

Please note that this is a breaking change and the extensions package _is not_ backwards compatible with dotnet core `2.x` It only works from `3.1` and onwards.

Closes #176 