### PR TITLE
Add props to tell whether locks have been taken immediately

### DIFF
--- a/src/core/main/Locking/IDistributedAppLock.cs
+++ b/src/core/main/Locking/IDistributedAppLock.cs
@@ -18,6 +18,16 @@ namespace RapidCore.Locking
         bool IsActive { get; }
 
         /// <summary>
+        /// Determines whether the lock was grabbed without applying retry logic 
+        /// </summary>
+        bool WasAcquiredInstantly { get; }
+        
+        /// <summary>
+        /// The total time spent on acquiring the lock including any retry time
+        /// </summary>
+        TimeSpan TimeUsedToAcquire { get; }
+        
+        /// <summary>
         /// When implemented in a downstream provider it will verify that the current instance of the lock is in an
         /// active (locked) state and has the name given to the method
         /// </summary>

--- a/src/core/main/Locking/NoopDistributedAppLock.cs
+++ b/src/core/main/Locking/NoopDistributedAppLock.cs
@@ -36,6 +36,10 @@ namespace RapidCore.Locking
         
         public bool IsActive { get; set; }
         
+        public bool WasAcquiredInstantly { get; } = true;
+        
+        public TimeSpan TimeUsedToAcquire { get; } = TimeSpan.Zero;
+
         /// <summary>
         /// Determines whether the current lock instance is <see cref="IsActive"/> and has a name that matches the given
         /// parameter

--- a/src/redis/test-functional/Locking/RedisDistributedAppLockProviderTest.cs
+++ b/src/redis/test-functional/Locking/RedisDistributedAppLockProviderTest.cs
@@ -88,7 +88,8 @@ namespace RapidCore.Redis.FunctionalTest.Locking
 
             var locker = new RedisDistributedAppLockProvider(_connectionPool);
             firstLock = (RedisDistributedAppLock) locker.Acquire(lockName, TimeSpan.FromSeconds(1));
-
+            Assert.True(firstLock.WasAcquiredInstantly);
+            
             // Create task to dispose of loclk at some point
             Task.Factory.StartNew(() =>
             {
@@ -100,6 +101,8 @@ namespace RapidCore.Redis.FunctionalTest.Locking
                 Task.Delay(TimeSpan.FromMilliseconds(500));
                 Assert.Equal(lockName, secondLock.Name);
                 Assert.True(secondLock.IsActive);
+                Assert.False((secondLock.WasAcquiredInstantly));
+                Assert.True(secondLock.TimeUsedToAcquire.Ticks > 0);
                 secondLock.Dispose();
             });
 

--- a/src/sqlserver/test-functional/Locking/SqlServerDistributedAppLockProviderTests.cs
+++ b/src/sqlserver/test-functional/Locking/SqlServerDistributedAppLockProviderTests.cs
@@ -118,7 +118,8 @@ namespace functionaltests.Locking
 
             var locker = new SqlServerDistributedAppLockProvider(_connectionFactory);
             firstLock = (SqlServerDistributedAppLock) locker.Acquire(lockName, TimeSpan.FromSeconds(1));
-
+            Assert.True(firstLock.WasAcquiredInstantly);
+            
             var threadStarted = false;
             // Create task to dispose of lock at some point
             Task.Factory.StartNew(() =>
@@ -139,6 +140,8 @@ namespace functionaltests.Locking
                 Task.Delay(TimeSpan.FromMilliseconds(500));
                 Assert.Equal(lockName, secondLock.Name);
                 Assert.True(secondLock.IsActive);
+                Assert.False(secondLock.WasAcquiredInstantly);
+                Assert.True(secondLock.TimeUsedToAcquire.Ticks > 0);
                 secondLock.Dispose();
             });
             

--- a/src/test-unit/Redis/Locking/RedisDistributedAppLockTest.cs
+++ b/src/test-unit/Redis/Locking/RedisDistributedAppLockTest.cs
@@ -179,5 +179,15 @@ namespace UnitTests.Redis.Locking
             Assert.Equal(DistributedAppLockExceptionReason.SeeInnerException, ex.Reason);
             Assert.IsType<OperationCanceledException>(ex.InnerException);
         }
+        
+        [Fact]
+        public async Task Does_set_lock_take_time_and_happened_immediately()
+        {
+            var handle = new RedisDistributedAppLock(_manager, _rng);
+            await handle.AcquireLockAsync(_defaultLockName);
+            
+            Assert.True(handle.WasAcquiredInstantly);
+            Assert.True(handle.TimeUsedToAcquire.Ticks > 0);
+        }
     }
 }


### PR DESCRIPTION
This PR:

- **adds** prop `WasAcquiredInstantly` that reflects whether the lock was acquired without invoking retry logic
- **adds** prop `TimeUsedToAcquire` that reflects the total amount of time spent acquiring the lock

Breaking change if someone out there has decided to extend our interfaces!