### PR TITLE
Fix the link to Code of Conduct on contributing page

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,7 +3,7 @@
 When contributing to this repository, please first discuss the change you wish to make via issue,
 email, or any other method with the owners of this repository before making a change.
 
-Please note we have a [code of conduct](./code_of_conduct), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](../code_of_conduct), please follow it in all your interactions with the project.
 
 
 ## Contributions


### PR DESCRIPTION
It is really annoying that the links can work locally, but not online...