### PR TITLE
In memory distributed app lock

### DIFF
--- a/docs/RapidCore.Locking/DistributedAppLock.md
+++ b/docs/RapidCore.Locking/DistributedAppLock.md
@@ -5,6 +5,7 @@ When you need to ensure that only 1 process (across all of your instances or ser
 You can implement your own or use one the implementations available in the RapidCore packages with dependencies:
 
 - Noop in `RapidCore` for when you really do not care, but the framework requires it
+- InMemory in `RapidCore` when it is known for sure that only 1 process is working on a resource
 - Redis in the package `RapidCore.Redis`
 - SqlServer in the package [`RapidCore.SqlServer`](../SqlServer/Locking.md)
 

--- a/src/core/main/Locking/InMemoryDistributedAppLock.cs
+++ b/src/core/main/Locking/InMemoryDistributedAppLock.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace RapidCore.Locking
+{
+    public class InMemoryDistributedAppLock : IDistributedAppLock
+    {
+        private bool _disposedValue; // To detect redundant calls
+        private readonly Random _rng;
+        private readonly ConcurrentDictionary<string, InMemoryDistributedAppLockSemaphore> _semaphores;
+
+        public InMemoryDistributedAppLock(Random rng, ConcurrentDictionary<string, InMemoryDistributedAppLockSemaphore> semaphores)
+        {
+            _rng = rng;
+            _semaphores = semaphores;
+        }
+
+        /// <summary>
+        /// Acquire the lock
+        /// </summary>
+        /// <param name="lockName">Name of the lock to acquire</param>
+        /// <param name="lockWaitTimeout">When set, the amount of time to wait for the lock to become available</param>
+        public async Task<IDistributedAppLock> AcquireLockAsync(string lockName, TimeSpan? lockWaitTimeout = null)
+        {
+            WasAcquiredInstantly = true;
+            var timeoutProvided = lockWaitTimeout.HasValue;
+            if (!timeoutProvided)
+            {
+                lockWaitTimeout = TimeSpan.Zero;
+            }
+            
+            InMemoryDistributedAppLockSemaphore semaphore;
+            lock (string.Intern(lockName))
+            {
+                semaphore = _semaphores.GetOrAdd(lockName, _ => new InMemoryDistributedAppLockSemaphore());
+                semaphore.IncrementReferenceCount(); // Remember that this lock is being referenced
+            }
+            
+            var timeout = TimeSpan.Zero;
+            
+            var stopWatch = new Stopwatch();
+            do
+            {
+                var lockWasAcquired = await semaphore.WaitAsync(timeout);
+                
+                if (!lockWasAcquired && !timeoutProvided)
+                {
+                    LockRelease(lockName);
+                    throw new DistributedAppLockException("Unable to acquire lock")
+                    {
+                        Reason = DistributedAppLockExceptionReason.LockAlreadyAcquired,
+                    };
+                }
+
+                if (!lockWasAcquired)
+                {
+                    WasAcquiredInstantly = false;
+                    timeout = TimeSpan.FromMilliseconds(_rng.Next(
+                        1,
+                        (int) Math.Min(2500, lockWaitTimeout.Value.TotalMilliseconds)
+                    )); // wait between 1 ms and either 2.5 seconds OR lockWaitTimeout if this is smaller than 2.5 seconds
+                    continue;
+                }
+
+                IsActive = true;
+                Name = lockName;
+                break;
+            } while (stopWatch.Elapsed.TotalSeconds < lockWaitTimeout.Value.TotalSeconds);
+
+            if (!IsActive)
+            {
+                LockRelease(lockName);
+                throw new DistributedAppLockException("Timeout while acquiring lock")
+                {
+                    Reason = DistributedAppLockExceptionReason.Timeout,
+                };
+            }
+            
+            TimeUsedToAcquire = stopWatch.Elapsed;
+            return this;
+        } 
+
+        /// <summary>
+        /// Determines whether the current lock instance is active (<see cref="IsActive"/>) and has a name that matches
+        /// the given parameter
+        /// </summary>
+        /// <param name="name">The name of the lock to assert that is currently taken</param>
+        /// <exception cref="InvalidOperationException">If the lock is not active or the name of the lock does not match
+        /// the provided name</exception>
+        public void ThrowIfNotActiveWithGivenName(string name)
+        {
+            if (!IsActive)
+            {
+                throw new InvalidOperationException(
+                    $"Lock precondition mismatch, required IsActive=true with name '{name}' but IsActive=false with name '{this.Name}'");
+            }
+
+            if (!Name.Equals(name))
+            {
+                throw new InvalidOperationException(
+                    $"Lock precondition mismatch, required IsActive=true with name '{name}' but IsActive=true with name '{this.Name}'");
+            }
+        }
+
+        /// <summary>
+        /// Release the lock (if it is active) and stop referencing the semaphore
+        /// </summary>
+        private void LockRelease(string lockName)
+        {
+            lock (string.Intern(lockName))
+            {
+                var semaphore = _semaphores[lockName];
+                if (IsActive)
+                {
+                    // Let someone else take the lock
+                    semaphore.Release();
+                }
+                semaphore.DecrementReferenceCount();
+                if (semaphore.ReferenceCount == 0) // If no one is referencing this semaphore, remove it to save space
+                {
+                    _semaphores.TryRemove(lockName, out _);
+                }
+            }
+        }
+
+        public string Name { get; private set; }
+        public bool IsActive { get; private set; }
+        public bool WasAcquiredInstantly { get; private set; }
+        public TimeSpan TimeUsedToAcquire { get; private set; }
+        
+        /// <summary>
+        /// Dispose of the lock instance and release the lock
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) below.
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposedValue)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                LockRelease(Name);
+                Name = default;
+                IsActive = false;
+            }
+
+            _disposedValue = true;
+        }
+
+        ~InMemoryDistributedAppLock()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/src/core/main/Locking/InMemoryDistributedAppLockProvider.cs
+++ b/src/core/main/Locking/InMemoryDistributedAppLockProvider.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace RapidCore.Locking
+{
+    public class InMemoryDistributedAppLockProvider : IDistributedAppLockProvider
+    {
+        private readonly Random _rng;
+        private readonly ConcurrentDictionary<string, InMemoryDistributedAppLockSemaphore> _semaphores;
+
+        public InMemoryDistributedAppLockProvider()
+        {
+            _rng = new Random();
+            _semaphores = new ConcurrentDictionary<string, InMemoryDistributedAppLockSemaphore>();
+        }
+        
+        public IDistributedAppLock Acquire(string lockName, TimeSpan? lockWaitTimeout = null, TimeSpan? lockAutoExpireTimeout = null)
+        {
+            var handle = new InMemoryDistributedAppLock(_rng, _semaphores);
+            var task = handle.AcquireLockAsync(lockName, lockWaitTimeout);
+
+            try
+            {
+                // wait for task to complete
+                return task.GetAwaiter().GetResult();
+            }
+            catch (AggregateException exception)
+            {
+                var innerException = exception.Flatten().InnerException;
+                if (innerException != null) throw innerException;
+                throw;
+            }
+        }
+
+        public async Task<IDistributedAppLock> AcquireAsync(string lockName, TimeSpan? lockWaitTimeout = null, TimeSpan? lockAutoExpireTimeout = null)
+        {
+            var handle = new InMemoryDistributedAppLock(_rng, _semaphores);
+            return await handle.AcquireLockAsync(lockName, lockWaitTimeout);
+        }
+    }
+}

--- a/src/core/main/Locking/InMemoryDistributedAppLockSemaphore.cs
+++ b/src/core/main/Locking/InMemoryDistributedAppLockSemaphore.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+
+namespace RapidCore.Locking
+{
+    public class InMemoryDistributedAppLockSemaphore : SemaphoreSlim
+    {
+        public int ReferenceCount { get; private set; }
+
+        public InMemoryDistributedAppLockSemaphore() : base(1, 1)
+        {
+            ReferenceCount = 0;
+        }
+
+        public void IncrementReferenceCount()
+        {
+            lock (this)
+            {
+                ++ReferenceCount;
+            }
+        }
+
+        public void DecrementReferenceCount()
+        {
+            lock (this)
+            {
+                --ReferenceCount;
+            }
+        }
+    }
+}

--- a/src/test-unit/Core/Locking/InMemoryDistributedAppLockProviderTest.cs
+++ b/src/test-unit/Core/Locking/InMemoryDistributedAppLockProviderTest.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Threading.Tasks;
+using RapidCore.Locking;
+using Xunit;
+
+namespace UnitTests.Core.Locking
+{
+    public class InMemoryDistributedAppLockProviderTest
+    {
+        [Fact]
+        public void Test_using_multiple_times_work()
+        {
+            var lockName = "first-lock";
+            
+            var locker = new InMemoryDistributedAppLockProvider();
+            using (locker.Acquire(lockName))
+            {
+                // mutual exclusion scope here
+            }
+            using (locker.Acquire(lockName))
+            {
+                // mutual exclusion scope here
+            }
+            using (locker.Acquire(lockName))
+            {
+                // mutual exclusion scope here
+            }
+        }
+
+        [Fact]
+        public void Test_cannot_acquire_lock_twice()
+        {
+            var lockName = "second-lock";
+            
+            var locker = new InMemoryDistributedAppLockProvider();
+
+            using (locker.Acquire(lockName, TimeSpan.FromSeconds(1)))
+            {
+                var ex = Assert.Throws<DistributedAppLockException>(() => locker.Acquire(lockName));
+                Assert.Equal(DistributedAppLockExceptionReason.LockAlreadyAcquired, ex.Reason);
+            }
+        }
+
+        [Fact]
+        public void Test_acquire_lock_with_timeout_works()
+        {
+            /*
+            This test flow goes something like:
+            1. acquire firstLock
+            2. Start a new thread that immediately returns and waits for a while
+            3. Try to acquire second lock, but be patient and wait for up to 20 secs while retrying
+            4. thread unlocks first lock after 700 ms
+            5. thread waits 500 ms
+            6. now we expect the second call to acquire to have succeeded, assert that this is true
+             */
+            InMemoryDistributedAppLock firstLock = null;
+            InMemoryDistributedAppLock secondLock = null;
+            var lockName = "some-other-lock";
+
+            var locker = new InMemoryDistributedAppLockProvider();
+            firstLock = (InMemoryDistributedAppLock) locker.Acquire(lockName, TimeSpan.FromSeconds(1));
+            Assert.True(firstLock.WasAcquiredInstantly);
+            
+            // Create task to dispose of lock at some point
+            Task.Factory.StartNew(() =>
+            {
+                Task.Delay(TimeSpan.FromMilliseconds(700));
+                // release the first lock
+                firstLock.Dispose();
+
+                // wait and the new lock should be acquired
+                Task.Delay(TimeSpan.FromMilliseconds(500));
+                Assert.Equal(lockName, secondLock.Name);
+                Assert.True(secondLock.IsActive);
+                Assert.False(secondLock.WasAcquiredInstantly);
+                Assert.True(secondLock.TimeUsedToAcquire.Ticks > 0);
+                secondLock.Dispose();
+            });
+
+            // this second lock now enters retry mode
+            secondLock = (InMemoryDistributedAppLock) locker.Acquire(lockName, TimeSpan.FromSeconds(20));
+        }
+
+        [Fact]
+        public void Test_that_is_active_is_false_when_disposed()
+        {
+            var provider = new InMemoryDistributedAppLockProvider();
+            var theLock = provider.Acquire("this-is-my-lock");
+            theLock.Dispose();
+            Assert.False(theLock.IsActive);
+        }
+
+        [Fact]
+        public async void Test_that_lock_is_released_on_exception_in_using_block()
+        {
+            var locker = new InMemoryDistributedAppLockProvider();
+            var lockName = "is_released_on_exception";
+            var lockWait = TimeSpan.FromSeconds(3);
+
+            try
+            {
+                using (await locker.AcquireAsync(lockName, lockWait))
+                {
+                    throw new InvalidOperationException("oh shit");
+                }
+            }
+            catch (Exception)
+            {
+                // nothing to do
+            }
+            
+            // we should be able to acquire the same lock now
+            using (await locker.AcquireAsync(lockName, lockWait))
+            {
+                // yay
+            }
+        }
+    }
+}


### PR DESCRIPTION
I think it could be nice to use the `IDistributedAppLockProvider` even for small projects that only run in a single process.
I have a small project, where I want to use a distributed app lock.
However, since it is small and I know that only one process will be running, I would like to avoid setting up a `Redis` server or `SqlServer` to keep track of my locks (until the project grows in size).
The existing `NoopDistributedAppLockProvider` is not sufficient, as it does not implement any locking at all.

I therefore propose a new implementation of `IDistributedAppLockProvider` and `IDistributedAppLock`, where the locks are simply stored in-memory instead of in a database.
I have tried implementing them, but a closer look would probably be beneficial.

Do you have any thoughts on this? Is it even something that RapidCore should maintain and support?