### PR TITLE
Add "sbyte", "IntPtr" and "UIntPtr" to list of non-traversed types

### DIFF
--- a/src/core/main/Reflection/InstanceTraverser.cs
+++ b/src/core/main/Reflection/InstanceTraverser.cs
@@ -236,9 +236,11 @@ namespace RapidCore.Reflection
         /// </summary>
         private readonly Dictionary<Type, bool> nonRecursedTypes = new Dictionary<Type, bool>
         {
+            // make sure to include the types from this list: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types
             { typeof(char), true },
             { typeof(bool), true },
             { typeof(byte), true },
+            { typeof(sbyte), true },
             { typeof(short), true },
             { typeof(ushort), true },
             { typeof(int), true },
@@ -248,6 +250,8 @@ namespace RapidCore.Reflection
             { typeof(float), true },
             { typeof(double), true },
             { typeof(decimal), true },
+            { typeof(IntPtr), true }, // nint
+            { typeof(UIntPtr), true}, // nuint
             { typeof(DateTime), true },
             { typeof(DateTimeOffset), true },
             { typeof(TimeSpan), true },

--- a/src/test-unit/Core/Reflection/InstanceTraverserTests/InstanceTraverser_RecursionTests.cs
+++ b/src/test-unit/Core/Reflection/InstanceTraverserTests/InstanceTraverser_RecursionTests.cs
@@ -564,6 +564,8 @@ namespace UnitTests.Core.Reflection.InstanceTraverserTests
             public bool? BoolNullable => true;
             public byte Byte => 4;
             public byte? ByteNullable => 4;
+            public sbyte SByte => 4;
+            public sbyte? SByteNullable => 4;
             public short Short => 5;
             public short? ShortNullable => 5;
             public ushort UShort => 6;
@@ -582,6 +584,10 @@ namespace UnitTests.Core.Reflection.InstanceTraverserTests
             public double? DoubleNullable => 123.23;
             public decimal Decimal => 123.467m;
             public decimal? DecimalNullable => 123.467m;
+            public IntPtr IntPtr => IntPtr.Zero;
+            public IntPtr? IntPtrNullable => IntPtr.Zero;
+            public UIntPtr UIntPtr => UIntPtr.Zero;
+            public UIntPtr? UIntPtrNullable => UIntPtr.Zero;
             public DateTime DateTime => DateTime.Now;
             public DateTime? DateTimeNullable => DateTime.Now;
             public DateTimeOffset DateTimeOffset => DateTimeOffset.Now;


### PR DESCRIPTION
In the same vain as #192, this PR adds a few more types to the list of non-traversed types (as used by `InstanceTraverser`)

- `sbyte`
- `IntPtr`
- `UIntPtr`